### PR TITLE
feat(cloudregistration): change to use partial registration api for updating event hub settings

### DIFF
--- a/scripts/Update-Registration.ps1
+++ b/scripts/Update-Registration.ps1
@@ -58,7 +58,7 @@ function Set-AzureEventHubsInfo {
     )
     try {
         $Params = @{
-            Uri     = "https://${FalconAPIBaseUrl}/cloud-security-registration-azure/entities/registrations/v1"
+            Uri     = "https://${FalconAPIBaseUrl}/cloud-security-registration-azure/entities/registrations/partial/v1"
             Method  = "PATCH"
             Headers = @{
                 "Authorization" = "Bearer ${AccessToken}"


### PR DESCRIPTION
# Scope

- Change to use `PATCH /cloud-security-registration-azure/entities/registrations/parial/v1` API for updating Event Hub settings back to FCS bacnend 