### PR TITLE
feature/zango/CSPG-87071/reduce-number-of-custom-roles-mg-scope-agentless-scanning  

### DIFF
--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -330,10 +330,10 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: entity.key
       locations: map(entity.value, location => {
         name: location
-        customScannersSubnet: contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })
@@ -342,10 +342,10 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: subscriptionId
       locations: map(validatedDspmLocations, location => {
         name: location
-        customScannersSubnet: contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })

--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -330,10 +330,16 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: entity.key
       locations: map(entity.value, location => {
         name: location
-        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })
@@ -342,10 +348,16 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: subscriptionId
       locations: map(validatedDspmLocations, location => {
         name: location
-        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })

--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -362,6 +362,10 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
           : ''
       })
     })
+
+/* Per-management-group subscription mapping from deployment scope */
+var subscriptionsByMg = shouldResolveDeploymentScope ? deploymentScope!.outputs.subscriptionsByManagementGroup : []
+
 module scanningEnvironment 'modules/cs-scanning-mg.bicep' = if (shouldDeployScanningEnvironment) {
   name: '${validatedResourceNamePrefix}cs-scanning-mg${environment}${validatedResourceNameSuffix}'
   params: {
@@ -369,6 +373,7 @@ module scanningEnvironment 'modules/cs-scanning-mg.bicep' = if (shouldDeployScan
     falconClientSecret: validatedFalconClientSecret
     scanningPrincipalId: azurePrincipalId
     scanningEnvironmentLocationsPerSubscriptionMap: scanningEnvironmentLocationsPerSubscriptionMap
+    subscriptionsByManagementGroup: subscriptionsByMg
     csInfraSubscriptionId: csInfraSubscriptionId
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
     agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -216,10 +216,10 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: entity.key
       locations: map(entity.value, location => {
         name: location
-        customScannersSubnet: contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })
@@ -228,10 +228,10 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: subscriptionId
       locations: map(validatedDspmLocations, location => {
         name: location
-        customScannersSubnet: contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -216,10 +216,16 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: entity.key
       locations: map(entity.value, location => {
         name: location
-        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: entity.key == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })
@@ -228,10 +234,16 @@ var scanningEnvironmentLocationsPerSubscriptionMap = !empty(validatedDspmLocatio
       subscriptionId: subscriptionId
       locations: map(validatedDspmLocations, location => {
         name: location
-        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customScannersSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].scanners_subnet_id
           : ''
-        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(validatedCustomVnetConfiguration, location)
+        customClonesSubnet: subscriptionId == agentlessScanningHostSubscriptionId && contains(
+            validatedCustomVnetConfiguration,
+            location
+          )
           ? validatedCustomVnetConfiguration[location].clones_subnet_id
           : ''
       })

--- a/models/scanning-roles.bicep
+++ b/models/scanning-roles.bicep
@@ -6,9 +6,9 @@
 */
 
 @export()
-@description('Permissions for the CrowdStrike Scanning Subscription Access Role.')
-var subscriptionAccessRolePermissions = {
-  description: 'CrowdStrike Scanning Subscription Access Role'
+@description('Permissions for the CrowdStrike Scanning Access Role.')
+var accessRolePermissions = {
+  description: 'CrowdStrike Scanning Access Role'
   actions: [
     // ============ Blob Storage ============
     'Microsoft.Storage/storageAccounts/read' // Check location and public access

--- a/models/scanning-roles.bicep
+++ b/models/scanning-roles.bicep
@@ -1,0 +1,93 @@
+/*
+  This Bicep template defines shared role permission definitions for CrowdStrike Scanning.
+  Single source of truth for all scanning role permissions used by both management group
+  and subscription deployment paths.
+  Copyright (c) 2026 CrowdStrike, Inc.
+*/
+
+@export()
+@description('Permissions for the CrowdStrike Scanning Subscription Access Role.')
+var subscriptionAccessRolePermissions = {
+  description: 'CrowdStrike Scanning Subscription Access Role'
+  actions: [
+    // ============ Blob Storage ============
+    'Microsoft.Storage/storageAccounts/read' // Check location and public access
+    'Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action' // Approve private link connections
+
+    // ============ Validation ============
+    'Microsoft.Authorization/roleAssignments/read'
+    'Microsoft.Authorization/policyDefinitions/read'
+  ]
+}
+
+@export()
+@description('Permissions for the CrowdStrike Scanning Subscription Scanner Role.')
+var scannerRolePermissions = {
+  description: 'CrowdStrike Scanning Subscription Scanner Role'
+  actions: [
+    'Microsoft.Storage/storageAccounts/blobServices/containers/read'
+  ]
+  dataActions: [
+    'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'
+  ]
+}
+
+@export()
+@description('Permissions for the CrowdStrike Agentless Scanning Resource Group Access Role.')
+var resourceGroupAccessRolePermissions = {
+  description: 'CrowdStrike Agentless Scanning Resource Group Access Role'
+  actions: [
+    // ============ Blob Storage ============
+    // Private Endpoint
+    'Microsoft.Network/privateEndpoints/read'
+    'Microsoft.Network/privateEndpoints/write'
+    'Microsoft.Network/privateEndpoints/delete'
+    'Microsoft.Network/virtualNetworks/subnets/join/action'
+
+    // ============ Scanner VM ============
+    'Microsoft.Network/networkSecurityGroups/read'
+    'Microsoft.Network/networkSecurityGroups/write'
+    'Microsoft.Network/networkSecurityGroups/delete'
+    'Microsoft.Network/networkInterfaces/read'
+    'Microsoft.Network/networkInterfaces/write'
+    'Microsoft.Network/networkInterfaces/delete'
+    'Microsoft.Network/networkInterfaces/join/action'
+    'Microsoft.Compute/virtualMachines/read'
+    'Microsoft.Compute/virtualMachines/write'
+    'Microsoft.Compute/virtualMachines/delete'
+    'Microsoft.Network/virtualNetworks/read'
+    'Microsoft.ManagedIdentity/userAssignedIdentities/read'
+    'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
+    'Microsoft.Resources/deployments/read'
+    'Microsoft.Resources/deployments/write'
+    'Microsoft.Resources/deployments/delete'
+    'Microsoft.Resources/deployments/operationStatuses/read'
+    'Microsoft.Resources/deploymentStacks/*'
+    // Always include delete permission for public IPs
+    'Microsoft.Network/publicIPAddresses/delete'
+
+    // ============ Validation ============
+    'Microsoft.Network/virtualNetworks/subnets/read'
+    'Microsoft.Resources/deployments/whatIf/action'
+    'Microsoft.Resources/deployments/validate/action'
+    'Microsoft.Resources/deploymentScripts/read'
+    'Microsoft.KeyVault/vaults/read'
+    'Microsoft.Compute/virtualMachines/retrieveBootDiagnosticsData/action'
+  ]
+  conditionalPublicIPActions: [
+    'Microsoft.Network/publicIPAddresses/read'
+    'Microsoft.Network/publicIPAddresses/write'
+    'Microsoft.Network/publicIPAddresses/join/action'
+  ]
+}
+
+@export()
+@description('Permissions for the CrowdStrike Custom VNet Subnet Access Role.')
+var customVnetSubnetRolePermissions = {
+  description: 'CrowdStrike Custom VNet Subnet Access Role'
+  actions: [
+    'Microsoft.Network/virtualNetworks/subnets/join/action'
+    'Microsoft.Network/virtualNetworks/read'
+    'Microsoft.Network/virtualNetworks/subnets/read'
+  ]
+}

--- a/models/scanning-roles.bicep
+++ b/models/scanning-roles.bicep
@@ -21,9 +21,9 @@ var accessRolePermissions = {
 }
 
 @export()
-@description('Permissions for the CrowdStrike Scanning Subscription Scanner Role.')
+@description('Permissions for the CrowdStrike Scanning Scanner Role.')
 var scannerRolePermissions = {
-  description: 'CrowdStrike Scanning Subscription Scanner Role'
+  description: 'CrowdStrike Scanning Scanner Role'
   actions: [
     'Microsoft.Storage/storageAccounts/blobServices/containers/read'
   ]

--- a/models/scanning-roles.bicep
+++ b/models/scanning-roles.bicep
@@ -6,9 +6,9 @@
 */
 
 @export()
-@description('Permissions for the CrowdStrike Scanning Access Role.')
+@description('Permissions for the CrowdStrike Agentless Scanning Access Role.')
 var accessRolePermissions = {
-  description: 'CrowdStrike Scanning Access Role'
+  description: 'CrowdStrike Agentless Scanning Access Role'
   actions: [
     // ============ Blob Storage ============
     'Microsoft.Storage/storageAccounts/read' // Check location and public access
@@ -21,9 +21,9 @@ var accessRolePermissions = {
 }
 
 @export()
-@description('Permissions for the CrowdStrike Scanning Scanner Role.')
+@description('Permissions for the CrowdStrike Agentless Scanning Scanner Role.')
 var scannerRolePermissions = {
-  description: 'CrowdStrike Scanning Scanner Role'
+  description: 'CrowdStrike Agentless Scanning Scanner Role'
   actions: [
     'Microsoft.Storage/storageAccounts/blobServices/containers/read'
   ]
@@ -82,9 +82,9 @@ var resourceGroupAccessRolePermissions = {
 }
 
 @export()
-@description('Permissions for the CrowdStrike Custom VNet Subnet Access Role.')
+@description('Permissions for the CrowdStrike Agentless Scanning Custom VNet Subnet Access Role.')
 var customVnetSubnetRolePermissions = {
-  description: 'CrowdStrike Custom VNet Subnet Access Role'
+  description: 'CrowdStrike Agentless Scanning Custom VNet Subnet Access Role'
   actions: [
     'Microsoft.Network/virtualNetworks/subnets/join/action'
     'Microsoft.Network/virtualNetworks/read'

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -2,7 +2,7 @@ targetScope = 'managementGroup'
 
 /*
   This Bicep template deploys infrastructure to enable CrowdStrike Scanning
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */
@@ -82,6 +82,17 @@ var verifiedCrossHostSubscriptionEntry = isCrossSubscriptionDeployment && length
   ? fail('"agentlessScanningHostSubscriptionId" must match a subscription in the scanning environment subscriptions map')
   : crossHostSubscriptionEntry
 
+// Define custom roles once at management group scope to avoid per-subscription role definition limits
+module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = {
+  name: '${resourceNamePrefix}cs-scanning-roles-mg${environment}${resourceNameSuffix}'
+  params: {
+    resourceNamePrefix: resourceNamePrefix
+    resourceNameSuffix: resourceNameSuffix
+    env: env
+    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+  }
+}
+
 // Cross-account mode: deploy full infra to host subscription first
 module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0) {
   name: '${resourceNamePrefix}cs-scanning-host${environment}${resourceNameSuffix}'
@@ -100,6 +111,9 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+    subscriptionAccessRoleId: scanningRoles.outputs.subscriptionAccessRoleId
+    scannerRoleId: scanningRoles.outputs.scannerRoleId
+    resourceGroupAccessRoleId: scanningRoles.outputs.resourceGroupAccessRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -131,6 +145,9 @@ module scanningSub 'scanning-environment/scanningSubBatch.bicep' = [
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+      subscriptionAccessRoleId: scanningRoles.outputs.subscriptionAccessRoleId
+      scannerRoleId: scanningRoles.outputs.scannerRoleId
+      resourceGroupAccessRoleId: scanningRoles.outputs.resourceGroupAccessRoleId
       resourceGroupName: resourceGroupName
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -144,7 +144,7 @@ var hostSubUseCustomSubnets = isCrossSubscriptionDeployment && length(verifiedCr
 
 /* Define custom roles at host MG scope (cross-account, host sub under MG) */
 module scanningHostMgRoles 'scanning-environment/scanningRolesForMg.bicep' = if (isHostSubUnderMg) {
-  name: '${resourceNamePrefix}cs-scanning-host-mg-roles-${uniqueString(hostMgEntries[0].managementGroupId)}${environment}${resourceNameSuffix}'
+  name: '${resourceNamePrefix}cs-scanning-host-mg-roles-${uniqueString(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)}${environment}${resourceNameSuffix}'
   scope: managementGroup(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)
   params: {
     resourceNamePrefix: resourceNamePrefix
@@ -172,7 +172,9 @@ module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
 /* Create per-subscription roles for host sub when it's not under any MG */
 module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (isHostSubStandalone) {
   name: '${resourceNamePrefix}cs-scanning-host-roles${environment}${resourceNameSuffix}'
-  scope: subscription(agentlessScanningHostSubscriptionId)
+  scope: subscription(isHostSubStandalone
+    ? agentlessScanningHostSubscriptionId
+    : scanningEnvironmentLocationsPerSubscriptionMap[0].subscriptionId)
   params: {
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -193,7 +195,9 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     falconClientId: falconClientId
     falconClientSecret: falconClientSecret
     scanningPrincipalId: scanningPrincipalId
-    scanningEnvironmentLocations: verifiedCrossHostSubscriptionEntry[0].locations
+    scanningEnvironmentLocations: isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0
+      ? verifiedCrossHostSubscriptionEntry[0].locations
+      : []
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
     agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
     inputEnableDspm: inputEnableDspm
@@ -220,7 +224,7 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
 
 /* Deploy scanning infrastructure for non-host subs in the host MG (cross-account) */
 module scanningHostPerMg 'scanning-environment/scanningForMg.bicep' = if (isHostSubUnderMg) {
-  name: '${resourceNamePrefix}cs-scanning-host-mg-${uniqueString(hostMgEntries[0].managementGroupId)}${environment}${resourceNameSuffix}'
+  name: '${resourceNamePrefix}cs-scanning-host-mg-${uniqueString(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)}${environment}${resourceNameSuffix}'
   scope: managementGroup(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)
   params: {
     subscriptionEntries: isHostSubUnderMg

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -164,9 +164,7 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-    subscriptionAccessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0
-      ? scanningRoles[0].outputs.subscriptionAccessRoleId
-      : ''
+    accessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0 ? scanningRoles[0].outputs.accessRoleId : ''
     scannerRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0 ? scanningRoles[0].outputs.scannerRoleId : ''
     resourceGroupAccessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0
       ? scanningRoles[0].outputs.resourceGroupAccessRoleId
@@ -194,7 +192,7 @@ module scanningPerMg 'scanning-environment/scanningForMg.bicep' = [
       scanningManagedIdentityPrincipalId: isCrossSubscriptionDeployment
         ? scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
         : ''
-      subscriptionAccessRoleId: scanningRoles[i].outputs.subscriptionAccessRoleId
+      accessRoleId: scanningRoles[i].outputs.accessRoleId
       scannerRoleId: scanningRoles[i].outputs.scannerRoleId
       resourceGroupAccessRoleId: scanningRoles[i].outputs.resourceGroupAccessRoleId
       csInfraSubscriptionId: csInfraSubscriptionId
@@ -230,7 +228,7 @@ module scanningStandaloneBatch 'scanning-environment/scanningSubBatch.bicep' = [
       scanningManagedIdentityPrincipalId: isCrossSubscriptionDeployment
         ? scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
         : ''
-      subscriptionAccessRoleId: ''
+      accessRoleId: ''
       scannerRoleId: ''
       resourceGroupAccessRoleId: ''
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -94,9 +94,7 @@ var mgEntriesWithSubscriptions = filter(
   entry => length(entry.subscriptionEntries) > 0
 )
 
-// Order: host MG first so that orderedMgEntries[0] is the MG containing the host subscription
-// when agentlessScanningHostSubscriptionId is provided (cross-account mode).
-// This allows scanningRoles[0] and scanningPerMg[0] to reference host MG resources by index.
+// MGs containing the host subscription vs all other MGs
 var hostMgEntries = isCrossSubscriptionDeployment
   ? filter(
       mgEntriesWithSubscriptions,
@@ -111,7 +109,6 @@ var nonHostMgEntries = isCrossSubscriptionDeployment
         empty(filter(entry.subscriptionEntries, sub => sub.subscriptionId == agentlessScanningHostSubscriptionId))
     )
   : mgEntriesWithSubscriptions
-var orderedMgEntries = concat(hostMgEntries, nonHostMgEntries)
 
 // Standalone subs (in scanning map but NOT under any MG)
 var allMgSubscriptionIds = flatten(map(
@@ -134,6 +131,9 @@ var isHostSubStandalone = isCrossSubscriptionDeployment && !empty(filter(
   sub => sub.subscriptionId == agentlessScanningHostSubscriptionId
 ))
 
+// Is host sub under a management group?
+var isHostSubUnderMg = isCrossSubscriptionDeployment && !isHostSubStandalone
+
 // Whether host sub uses custom VNet subnets (for custom VNet role creation)
 var hostSubUseCustomSubnets = isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0
   ? length(filter(
@@ -142,17 +142,29 @@ var hostSubUseCustomSubnets = isCrossSubscriptionDeployment && length(verifiedCr
     )) > 0
   : false
 
-/* Define custom roles at each management group scope */
+/* Define custom roles at host MG scope (cross-account, host sub under MG) */
+module scanningHostMgRoles 'scanning-environment/scanningRolesForMg.bicep' = if (isHostSubUnderMg) {
+  name: '${resourceNamePrefix}cs-scanning-host-mg-roles-${uniqueString(hostMgEntries[0].managementGroupId)}${environment}${resourceNameSuffix}'
+  scope: managementGroup(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)
+  params: {
+    resourceNamePrefix: resourceNamePrefix
+    resourceNameSuffix: resourceNameSuffix
+    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    includeResourceGroupAccessRole: true
+    useCustomSubnets: hostSubUseCustomSubnets
+  }
+}
+
+/* Define custom roles at each non-host management group scope */
 module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
-  for (mgEntry, i) in orderedMgEntries: {
+  for mgEntry in nonHostMgEntries: {
     name: '${resourceNamePrefix}cs-scanning-roles-${uniqueString(mgEntry.managementGroupId)}${environment}${resourceNameSuffix}'
     scope: managementGroup(mgEntry.managementGroupId)
     params: {
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
-      includeResourceGroupAccessRole: !isCrossSubscriptionDeployment || i == 0
-      useCustomSubnets: i == 0 && hostSubUseCustomSubnets
+      includeResourceGroupAccessRole: !isCrossSubscriptionDeployment
     }
   }
 ]
@@ -188,16 +200,16 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-    accessRoleId: isHostSubStandalone ? scanningHostRoles!.outputs.accessRoleId : scanningRoles[0].outputs.accessRoleId
-    scannerRoleId: isHostSubStandalone
-      ? scanningHostRoles!.outputs.scannerRoleId
-      : scanningRoles[0].outputs.scannerRoleId
-    resourceGroupAccessRoleId: isHostSubStandalone
-      ? scanningHostRoles!.outputs.resourceGroupAccessRoleId
-      : scanningRoles[0].outputs.resourceGroupAccessRoleId
-    customVnetSubnetRoleId: isHostSubStandalone
-      ? scanningHostRoles!.outputs.customVnetSubnetRoleId
-      : scanningRoles[0].outputs.customVnetSubnetRoleId
+    accessRoleId: isHostSubUnderMg ? scanningHostMgRoles!.outputs.accessRoleId : scanningHostRoles!.outputs.accessRoleId
+    scannerRoleId: isHostSubUnderMg
+      ? scanningHostMgRoles!.outputs.scannerRoleId
+      : scanningHostRoles!.outputs.scannerRoleId
+    resourceGroupAccessRoleId: isHostSubUnderMg
+      ? scanningHostMgRoles!.outputs.resourceGroupAccessRoleId
+      : scanningHostRoles!.outputs.resourceGroupAccessRoleId
+    customVnetSubnetRoleId: isHostSubUnderMg
+      ? scanningHostMgRoles!.outputs.customVnetSubnetRoleId
+      : scanningHostRoles!.outputs.customVnetSubnetRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -206,15 +218,44 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
   }
 }
 
-/* Deploy scanning infrastructure per management group */
+/* Deploy scanning infrastructure for non-host subs in the host MG (cross-account) */
+module scanningHostPerMg 'scanning-environment/scanningForMg.bicep' = if (isHostSubUnderMg) {
+  name: '${resourceNamePrefix}cs-scanning-host-mg-${uniqueString(hostMgEntries[0].managementGroupId)}${environment}${resourceNameSuffix}'
+  scope: managementGroup(isHostSubUnderMg ? hostMgEntries[0].managementGroupId : managementGroup().name)
+  params: {
+    subscriptionEntries: isHostSubUnderMg
+      ? filter(hostMgEntries[0].subscriptionEntries, sub => sub.subscriptionId != agentlessScanningHostSubscriptionId)
+      : []
+    falconClientId: falconClientId
+    falconClientSecret: falconClientSecret
+    scanningPrincipalId: scanningPrincipalId
+    scanningManagedIdentityPrincipalId: scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
+    accessRoleId: scanningHostMgRoles!.outputs.accessRoleId
+    scannerRoleId: scanningHostMgRoles!.outputs.scannerRoleId
+    resourceGroupAccessRoleId: scanningHostMgRoles!.outputs.resourceGroupAccessRoleId
+    csInfraSubscriptionId: csInfraSubscriptionId
+    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
+    inputEnableDspm: inputEnableDspm
+    inputAgentlessScanningLocations: inputAgentlessScanningLocations
+    inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
+    inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+    resourceGroupName: resourceGroupName
+    resourceNamePrefix: resourceNamePrefix
+    resourceNameSuffix: resourceNameSuffix
+    env: env
+    tags: tags
+    batchSize: batchSize
+  }
+}
+
+/* Deploy scanning infrastructure for non-host management groups */
 module scanningPerMg 'scanning-environment/scanningForMg.bicep' = [
-  for (mgEntry, i) in orderedMgEntries: {
+  for (mgEntry, i) in nonHostMgEntries: {
     name: '${resourceNamePrefix}cs-scanning-mg-${uniqueString(mgEntry.managementGroupId)}${environment}${resourceNameSuffix}'
     scope: managementGroup(mgEntry.managementGroupId)
     params: {
-      subscriptionEntries: isCrossSubscriptionDeployment
-        ? filter(mgEntry.subscriptionEntries, sub => sub.subscriptionId != agentlessScanningHostSubscriptionId)
-        : mgEntry.subscriptionEntries
+      subscriptionEntries: mgEntry.subscriptionEntries
       falconClientId: falconClientId
       falconClientSecret: falconClientSecret
       scanningPrincipalId: scanningPrincipalId

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -146,6 +146,18 @@ module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
   }
 ]
 
+/* Create per-subscription roles for host sub when it's not under any MG */
+module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (isHostSubStandalone) {
+  name: '${resourceNamePrefix}cs-scanning-host-roles${environment}${resourceNameSuffix}'
+  scope: subscription(agentlessScanningHostSubscriptionId)
+  params: {
+    resourceNamePrefix: resourceNamePrefix
+    resourceNameSuffix: resourceNameSuffix
+    env: env
+    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+  }
+}
+
 // Cross-account mode: deploy full infra to host subscription first
 module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0) {
   name: '${resourceNamePrefix}cs-scanning-host${environment}${resourceNameSuffix}'
@@ -164,11 +176,13 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-    accessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0 ? scanningRoles[0].outputs.accessRoleId : ''
-    scannerRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0 ? scanningRoles[0].outputs.scannerRoleId : ''
-    resourceGroupAccessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0
-      ? scanningRoles[0].outputs.resourceGroupAccessRoleId
-      : ''
+    accessRoleId: isHostSubStandalone ? scanningHostRoles!.outputs.accessRoleId : scanningRoles[0].outputs.accessRoleId
+    scannerRoleId: isHostSubStandalone
+      ? scanningHostRoles!.outputs.scannerRoleId
+      : scanningRoles[0].outputs.scannerRoleId
+    resourceGroupAccessRoleId: isHostSubStandalone
+      ? scanningHostRoles!.outputs.resourceGroupAccessRoleId
+      : scanningRoles[0].outputs.resourceGroupAccessRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -19,6 +19,9 @@ param scanningPrincipalId string
 @description('Azure locations (regions) where scanning environments will be deployed as subscription ID to locations map.')
 param scanningEnvironmentLocationsPerSubscriptionMap array = []
 
+@description('Per-management-group active subscription IDs from deployment scope. Each entry contains managementGroupId and activeSubscriptionIds array.')
+param subscriptionsByManagementGroup array = []
+
 @description('Name of the resource group where CrowdStrike infrastructure resources will be deployed.')
 param resourceGroupName string
 
@@ -72,26 +75,76 @@ var crossHostSubscriptionEntry = isCrossSubscriptionDeployment
       sub => sub.subscriptionId == agentlessScanningHostSubscriptionId
     )
   : []
-var nonCrossHostSubscriptionEntries = isCrossSubscriptionDeployment
-  ? filter(
-      scanningEnvironmentLocationsPerSubscriptionMap,
-      sub => sub.subscriptionId != agentlessScanningHostSubscriptionId
-    )
-  : scanningEnvironmentLocationsPerSubscriptionMap
 var verifiedCrossHostSubscriptionEntry = isCrossSubscriptionDeployment && length(crossHostSubscriptionEntry) == 0
   ? fail('"agentlessScanningHostSubscriptionId" must match a subscription in the scanning environment subscriptions map')
   : crossHostSubscriptionEntry
 
-// Define custom roles once at management group scope to avoid per-subscription role definition limits
-module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = {
-  name: '${resourceNamePrefix}cs-scanning-roles-mg${environment}${resourceNameSuffix}'
-  params: {
-    resourceNamePrefix: resourceNamePrefix
-    resourceNameSuffix: resourceNameSuffix
-    env: env
-    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+// Intersect MG subscription IDs with the scanning map to get per-MG scanning entries
+var scanningEntriesByManagementGroup = map(subscriptionsByManagementGroup, mgEntry => {
+  managementGroupId: mgEntry.managementGroupId
+  subscriptionEntries: filter(
+    scanningEnvironmentLocationsPerSubscriptionMap,
+    entry => contains(mgEntry.activeSubscriptionIds, entry.subscriptionId)
+  )
+})
+
+// Filter to MGs that have scanning subscriptions
+var mgEntriesWithSubscriptions = filter(
+  scanningEntriesByManagementGroup,
+  entry => length(entry.subscriptionEntries) > 0
+)
+
+// Order: host MG first (so scanningRoles[0] = host MG's roles)
+var hostMgEntries = isCrossSubscriptionDeployment
+  ? filter(
+      mgEntriesWithSubscriptions,
+      entry =>
+        !empty(filter(entry.subscriptionEntries, sub => sub.subscriptionId == agentlessScanningHostSubscriptionId))
+    )
+  : []
+var nonHostMgEntries = isCrossSubscriptionDeployment
+  ? filter(
+      mgEntriesWithSubscriptions,
+      entry =>
+        empty(filter(entry.subscriptionEntries, sub => sub.subscriptionId == agentlessScanningHostSubscriptionId))
+    )
+  : mgEntriesWithSubscriptions
+var orderedMgEntries = concat(hostMgEntries, nonHostMgEntries)
+
+// Standalone subs (in scanning map but NOT under any MG)
+var allMgSubscriptionIds = flatten(map(
+  scanningEntriesByManagementGroup,
+  entry => map(entry.subscriptionEntries, sub => sub.subscriptionId)
+))
+var standaloneSubscriptionEntries = filter(
+  scanningEnvironmentLocationsPerSubscriptionMap,
+  entry => !contains(allMgSubscriptionIds, entry.subscriptionId)
+)
+
+// Cross-account: exclude host from standalone batch (host is deployed separately)
+var nonHostStandaloneEntries = isCrossSubscriptionDeployment
+  ? filter(standaloneSubscriptionEntries, sub => sub.subscriptionId != agentlessScanningHostSubscriptionId)
+  : standaloneSubscriptionEntries
+
+// Is host sub standalone (not under any MG)?
+var isHostSubStandalone = isCrossSubscriptionDeployment && !empty(filter(
+  standaloneSubscriptionEntries,
+  sub => sub.subscriptionId == agentlessScanningHostSubscriptionId
+))
+
+/* Define custom roles at each management group scope */
+module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
+  for mgEntry in orderedMgEntries: {
+    name: '${resourceNamePrefix}cs-scanning-roles-${uniqueString(mgEntry.managementGroupId)}${environment}${resourceNameSuffix}'
+    scope: managementGroup(mgEntry.managementGroupId)
+    params: {
+      resourceNamePrefix: resourceNamePrefix
+      resourceNameSuffix: resourceNameSuffix
+      env: env
+      agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    }
   }
-}
+]
 
 // Cross-account mode: deploy full infra to host subscription first
 module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0) {
@@ -111,9 +164,13 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-    subscriptionAccessRoleId: scanningRoles.outputs.subscriptionAccessRoleId
-    scannerRoleId: scanningRoles.outputs.scannerRoleId
-    resourceGroupAccessRoleId: scanningRoles.outputs.resourceGroupAccessRoleId
+    subscriptionAccessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0
+      ? scanningRoles[0].outputs.subscriptionAccessRoleId
+      : ''
+    scannerRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0 ? scanningRoles[0].outputs.scannerRoleId : ''
+    resourceGroupAccessRoleId: !isHostSubStandalone && length(orderedMgEntries) > 0
+      ? scanningRoles[0].outputs.resourceGroupAccessRoleId
+      : ''
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -122,32 +179,66 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
   }
 }
 
-// Per-account mode: deploy full infra to every subscription
-// Cross-account mode: deploy role assignments only to non-host subscriptions
-// Deploy in batches to handle 800+ subscriptions
-var totalSubscriptions = length(nonCrossHostSubscriptionEntries)
-var numberOfBatches = totalSubscriptions == 0 ? 0 : (totalSubscriptions + batchSize - 1) / batchSize
-module scanningSub 'scanning-environment/scanningSubBatch.bicep' = [
-  for i in range(0, numberOfBatches): {
-    name: '${resourceNamePrefix}cs-scanning-batch-${i}${environment}${resourceNameSuffix}'
-    scope: subscription(csInfraSubscriptionId)
+/* Deploy scanning infrastructure per management group */
+module scanningPerMg 'scanning-environment/scanningForMg.bicep' = [
+  for (mgEntry, i) in orderedMgEntries: {
+    name: '${resourceNamePrefix}cs-scanning-mg-${uniqueString(mgEntry.managementGroupId)}${environment}${resourceNameSuffix}'
+    scope: managementGroup(mgEntry.managementGroupId)
     params: {
-      subscriptionEntries: take(skip(nonCrossHostSubscriptionEntries, i * batchSize), batchSize)
+      subscriptionEntries: isCrossSubscriptionDeployment
+        ? filter(mgEntry.subscriptionEntries, sub => sub.subscriptionId != agentlessScanningHostSubscriptionId)
+        : mgEntry.subscriptionEntries
       falconClientId: falconClientId
       falconClientSecret: falconClientSecret
       scanningPrincipalId: scanningPrincipalId
       scanningManagedIdentityPrincipalId: isCrossSubscriptionDeployment
         ? scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
         : ''
+      subscriptionAccessRoleId: scanningRoles[i].outputs.subscriptionAccessRoleId
+      scannerRoleId: scanningRoles[i].outputs.scannerRoleId
+      resourceGroupAccessRoleId: scanningRoles[i].outputs.resourceGroupAccessRoleId
+      csInfraSubscriptionId: csInfraSubscriptionId
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
       agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
       inputEnableDspm: inputEnableDspm
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-      subscriptionAccessRoleId: scanningRoles.outputs.subscriptionAccessRoleId
-      scannerRoleId: scanningRoles.outputs.scannerRoleId
-      resourceGroupAccessRoleId: scanningRoles.outputs.resourceGroupAccessRoleId
+      resourceGroupName: resourceGroupName
+      resourceNamePrefix: resourceNamePrefix
+      resourceNameSuffix: resourceNameSuffix
+      env: env
+      tags: tags
+      batchSize: batchSize
+    }
+  }
+]
+
+/* Deploy scanning for standalone subscriptions (not under any management group) */
+var totalStandaloneSubs = length(nonHostStandaloneEntries)
+var standaloneNumberOfBatches = totalStandaloneSubs == 0 ? 0 : (totalStandaloneSubs + batchSize - 1) / batchSize
+
+module scanningStandaloneBatch 'scanning-environment/scanningSubBatch.bicep' = [
+  for i in range(0, standaloneNumberOfBatches): {
+    name: '${resourceNamePrefix}cs-scanning-standalone-${i}${environment}${resourceNameSuffix}'
+    scope: subscription(csInfraSubscriptionId)
+    params: {
+      subscriptionEntries: take(skip(nonHostStandaloneEntries, i * batchSize), batchSize)
+      falconClientId: falconClientId
+      falconClientSecret: falconClientSecret
+      scanningPrincipalId: scanningPrincipalId
+      scanningManagedIdentityPrincipalId: isCrossSubscriptionDeployment
+        ? scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
+        : ''
+      subscriptionAccessRoleId: ''
+      scannerRoleId: ''
+      resourceGroupAccessRoleId: ''
+      agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+      agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
+      inputEnableDspm: inputEnableDspm
+      inputAgentlessScanningLocations: inputAgentlessScanningLocations
+      inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
+      inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
       resourceGroupName: resourceGroupName
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -94,7 +94,9 @@ var mgEntriesWithSubscriptions = filter(
   entry => length(entry.subscriptionEntries) > 0
 )
 
-// Order: host MG first (so scanningRoles[0] = host MG's roles)
+// Order: host MG first so that orderedMgEntries[0] is the MG containing the host subscription
+// when agentlessScanningHostSubscriptionId is provided (cross-account mode).
+// This allows scanningRoles[0] and scanningPerMg[0] to reference host MG resources by index.
 var hostMgEntries = isCrossSubscriptionDeployment
   ? filter(
       mgEntriesWithSubscriptions,
@@ -132,9 +134,17 @@ var isHostSubStandalone = isCrossSubscriptionDeployment && !empty(filter(
   sub => sub.subscriptionId == agentlessScanningHostSubscriptionId
 ))
 
+// Whether host sub uses custom VNet subnets (for custom VNet role creation)
+var hostSubUseCustomSubnets = isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0
+  ? length(filter(
+      verifiedCrossHostSubscriptionEntry[0].locations,
+      location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
+    )) > 0
+  : false
+
 /* Define custom roles at each management group scope */
 module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
-  for mgEntry in orderedMgEntries: {
+  for (mgEntry, i) in orderedMgEntries: {
     name: '${resourceNamePrefix}cs-scanning-roles-${uniqueString(mgEntry.managementGroupId)}${environment}${resourceNameSuffix}'
     scope: managementGroup(mgEntry.managementGroupId)
     params: {
@@ -142,6 +152,8 @@ module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
       resourceNameSuffix: resourceNameSuffix
       env: env
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+      includeResourceGroupAccessRole: !isCrossSubscriptionDeployment || i == 0
+      useCustomSubnets: i == 0 && hostSubUseCustomSubnets
     }
   }
 ]
@@ -155,6 +167,8 @@ module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (
     resourceNameSuffix: resourceNameSuffix
     env: env
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    includeResourceGroupAccessRole: true
+    useCustomSubnets: hostSubUseCustomSubnets
   }
 }
 
@@ -183,6 +197,9 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     resourceGroupAccessRoleId: isHostSubStandalone
       ? scanningHostRoles!.outputs.resourceGroupAccessRoleId
       : scanningRoles[0].outputs.resourceGroupAccessRoleId
+    customVnetSubnetRoleId: isHostSubStandalone
+      ? scanningHostRoles!.outputs.customVnetSubnetRoleId
+      : scanningRoles[0].outputs.customVnetSubnetRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -245,6 +262,7 @@ module scanningStandaloneBatch 'scanning-environment/scanningSubBatch.bicep' = [
       accessRoleId: ''
       scannerRoleId: ''
       resourceGroupAccessRoleId: ''
+      includeResourceGroupAccessRole: !isCrossSubscriptionDeployment
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
       agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
       inputEnableDspm: inputEnableDspm

--- a/modules/cs-scanning-mg.bicep
+++ b/modules/cs-scanning-mg.bicep
@@ -150,7 +150,6 @@ module scanningRoles 'scanning-environment/scanningRolesForMg.bicep' = [
     params: {
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix
-      env: env
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
       includeResourceGroupAccessRole: !isCrossSubscriptionDeployment || i == 0
       useCustomSubnets: i == 0 && hostSubUseCustomSubnets
@@ -165,7 +164,6 @@ module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (
   params: {
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
-    env: env
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
     includeResourceGroupAccessRole: true
     useCustomSubnets: hostSubUseCustomSubnets

--- a/modules/cs-scanning-sub.bicep
+++ b/modules/cs-scanning-sub.bicep
@@ -79,6 +79,14 @@ var verifiedCrossHostSubscriptionEntry = isCrossSubscriptionDeployment && length
   ? fail('"agentlessScanningHostSubscriptionId" must match a subscription in the scanning environment subscriptions map')
   : crossHostSubscriptionEntry
 
+// Whether host sub uses custom VNet subnets (for custom VNet role creation)
+var hostSubUseCustomSubnets = isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0
+  ? length(filter(
+      verifiedCrossHostSubscriptionEntry[0].locations,
+      location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
+    )) > 0
+  : false
+
 // Cross-account mode: create per-subscription roles for host sub
 module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (isCrossSubscriptionDeployment) {
   name: '${resourceNamePrefix}cs-scanning-host-roles${environment}${resourceNameSuffix}'
@@ -90,6 +98,8 @@ module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (
     resourceNameSuffix: resourceNameSuffix
     env: env
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    includeResourceGroupAccessRole: true
+    useCustomSubnets: hostSubUseCustomSubnets
   }
 }
 
@@ -114,6 +124,7 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     accessRoleId: scanningHostRoles!.outputs.accessRoleId
     scannerRoleId: scanningHostRoles!.outputs.scannerRoleId
     resourceGroupAccessRoleId: scanningHostRoles!.outputs.resourceGroupAccessRoleId
+    customVnetSubnetRoleId: scanningHostRoles!.outputs.customVnetSubnetRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -138,6 +149,7 @@ module scanningSub 'scanning-environment/scanningSubBatch.bicep' = [
       scanningManagedIdentityPrincipalId: isCrossSubscriptionDeployment
         ? scanningHostSub!.outputs.scanningManagedIdentityPrincipalId
         : ''
+      includeResourceGroupAccessRole: !isCrossSubscriptionDeployment
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
       agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
       inputEnableDspm: inputEnableDspm

--- a/modules/cs-scanning-sub.bicep
+++ b/modules/cs-scanning-sub.bicep
@@ -113,7 +113,9 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     falconClientId: falconClientId
     falconClientSecret: falconClientSecret
     scanningPrincipalId: scanningPrincipalId
-    scanningEnvironmentLocations: verifiedCrossHostSubscriptionEntry[0].locations
+    scanningEnvironmentLocations: isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0
+      ? verifiedCrossHostSubscriptionEntry[0].locations
+      : []
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
     agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
     inputEnableDspm: inputEnableDspm

--- a/modules/cs-scanning-sub.bicep
+++ b/modules/cs-scanning-sub.bicep
@@ -79,6 +79,20 @@ var verifiedCrossHostSubscriptionEntry = isCrossSubscriptionDeployment && length
   ? fail('"agentlessScanningHostSubscriptionId" must match a subscription in the scanning environment subscriptions map')
   : crossHostSubscriptionEntry
 
+// Cross-account mode: create per-subscription roles for host sub
+module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (isCrossSubscriptionDeployment) {
+  name: '${resourceNamePrefix}cs-scanning-host-roles${environment}${resourceNameSuffix}'
+  scope: subscription(isCrossSubscriptionDeployment
+    ? agentlessScanningHostSubscriptionId
+    : scanningEnvironmentLocationsPerSubscriptionMap[0].subscriptionId)
+  params: {
+    resourceNamePrefix: resourceNamePrefix
+    resourceNameSuffix: resourceNameSuffix
+    env: env
+    agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+  }
+}
+
 // Cross-account mode: deploy full infra to host subscription first
 module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCrossSubscriptionDeployment && length(verifiedCrossHostSubscriptionEntry) > 0) {
   name: '${resourceNamePrefix}cs-scanning-host${environment}${resourceNameSuffix}'
@@ -97,6 +111,9 @@ module scanningHostSub 'scanning-environment/scanningForSub.bicep' = if (isCross
     inputAgentlessScanningLocations: inputAgentlessScanningLocations
     inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
     inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+    accessRoleId: scanningHostRoles!.outputs.accessRoleId
+    scannerRoleId: scanningHostRoles!.outputs.scannerRoleId
+    resourceGroupAccessRoleId: scanningHostRoles!.outputs.resourceGroupAccessRoleId
     resourceGroupName: resourceGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix

--- a/modules/cs-scanning-sub.bicep
+++ b/modules/cs-scanning-sub.bicep
@@ -96,7 +96,6 @@ module scanningHostRoles 'scanning-environment/scanningRolesForSub.bicep' = if (
   params: {
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
-    env: env
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
     includeResourceGroupAccessRole: true
     useCustomSubnets: hostSubUseCustomSubnets

--- a/modules/cs-scanning-sub.bicep
+++ b/modules/cs-scanning-sub.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 /*
   This Bicep template deploys infrastructure to enable CrowdStrike Scanning
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */

--- a/modules/scanning-environment/customVnetRoleAssignment.bicep
+++ b/modules/scanning-environment/customVnetRoleAssignment.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 /*
   This Bicep module creates a role assignment for CrowdStrike scanning subnet access
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 @description('Principal ID of the CrowdStrike service principal.')

--- a/modules/scanning-environment/scanningForMg.bicep
+++ b/modules/scanning-environment/scanningForMg.bicep
@@ -84,7 +84,7 @@ var numberOfBatches = totalSubscriptions == 0 ? 0 : (totalSubscriptions + batchS
 /* Deploy scanning infrastructure in batches */
 module scanningSub 'scanningSubBatch.bicep' = [
   for i in range(0, numberOfBatches): {
-    name: '${resourceNamePrefix}cs-scanning-batch-${i}${environment}${resourceNameSuffix}'
+    name: '${resourceNamePrefix}cs-sc-${uniqueString(managementGroup().name)}-${i}${environment}${resourceNameSuffix}'
     scope: subscription(csInfraSubscriptionId)
     params: {
       subscriptionEntries: take(skip(subscriptionEntries, i * batchSize), batchSize)

--- a/modules/scanning-environment/scanningForMg.bicep
+++ b/modules/scanning-environment/scanningForMg.bicep
@@ -1,0 +1,111 @@
+targetScope = 'managementGroup'
+
+/*
+  This Bicep template deploys scanning infrastructure for all subscriptions within a
+  single management group. It handles batching internally to overcome the 800 iteration limit.
+  Copyright (c) 2026 CrowdStrike, Inc.
+*/
+
+/* Parameters */
+@description('Subscription entries with their scanning locations for this management group.')
+param subscriptionEntries array
+
+@description('Client ID for the Falcon API.')
+param falconClientId string
+
+@description('Client secret for the Falcon API.')
+@secure()
+param falconClientSecret string
+
+@description('Principal ID of the CrowdStrike application registered in Entra ID. This ID is used for role assignments and access control.')
+param scanningPrincipalId string
+
+@description('Principal ID of the scanning managed identity from the host subscription. Used in cross-account mode for non-host subscriptions.')
+param scanningManagedIdentityPrincipalId string = ''
+
+@description('Name of the resource group where CrowdStrike infrastructure resources will be deployed.')
+param resourceGroupName string
+
+@maxLength(10)
+@description('Optional prefix added to all resource names for organization and identification purposes.')
+param resourceNamePrefix string = ''
+
+@maxLength(10)
+@description('Optional suffix added to all resource names for organization and identification purposes.')
+param resourceNameSuffix string = ''
+
+@maxLength(4)
+@description('Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments.')
+param env string
+
+@description('Tags to be applied to all deployed resources. Used for resource organization, governance, and cost tracking.')
+param tags object
+
+@description('Subscription ID where CrowdStrike infrastructure resources will be deployed. Used as the deployment scope for batch modules.')
+param csInfraSubscriptionId string
+
+@description('Controls whether to deploy NAT Gateway for scanning environment.')
+param agentlessScanningDeployNatGateway bool = true
+
+@description('Azure agentless scanning host subscription ID.')
+param agentlessScanningHostSubscriptionId string = ''
+
+@description('Controls whether to enable DSPM.')
+param inputEnableDspm bool = false
+
+@description('Azure locations (regions) where DSPM will be deployed.')
+param inputAgentlessScanningLocations array = []
+
+@description('Azure locations (regions) where DSPM will be deployed as subscription ID to locations map.')
+param inputAgentlessScanningLocationsPerSubscription object = {}
+
+@description('Per-region custom VNet configuration for agentless scanning.')
+param inputAgentlessScanningCustomVnetConfiguration object = {}
+
+@description('Role definition ID for subscription access role from management group scope.')
+param subscriptionAccessRoleId string = ''
+
+@description('Role definition ID for scanner role from management group scope.')
+param scannerRoleId string = ''
+
+@description('Role definition ID for resource group access role from management group scope.')
+param resourceGroupAccessRoleId string = ''
+
+@description('Maximum number of subscriptions per batch for scanning deployment. Default is 750 to stay safely under the 800 limit.')
+@minValue(1)
+@maxValue(800)
+param batchSize int = 750
+
+/* Variables */
+var environment = length(env) > 0 ? '-${env}' : env
+var totalSubscriptions = length(subscriptionEntries)
+var numberOfBatches = totalSubscriptions == 0 ? 0 : (totalSubscriptions + batchSize - 1) / batchSize
+
+/* Deploy scanning infrastructure in batches */
+module scanningSub 'scanningSubBatch.bicep' = [
+  for i in range(0, numberOfBatches): {
+    name: '${resourceNamePrefix}cs-scanning-batch-${i}${environment}${resourceNameSuffix}'
+    scope: subscription(csInfraSubscriptionId)
+    params: {
+      subscriptionEntries: take(skip(subscriptionEntries, i * batchSize), batchSize)
+      falconClientId: falconClientId
+      falconClientSecret: falconClientSecret
+      scanningPrincipalId: scanningPrincipalId
+      scanningManagedIdentityPrincipalId: scanningManagedIdentityPrincipalId
+      agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+      agentlessScanningHostSubscriptionId: agentlessScanningHostSubscriptionId
+      inputEnableDspm: inputEnableDspm
+      inputAgentlessScanningLocations: inputAgentlessScanningLocations
+      inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
+      inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+      subscriptionAccessRoleId: subscriptionAccessRoleId
+      scannerRoleId: scannerRoleId
+      resourceGroupAccessRoleId: resourceGroupAccessRoleId
+      resourceGroupName: resourceGroupName
+      resourceNamePrefix: resourceNamePrefix
+      resourceNameSuffix: resourceNameSuffix
+      env: env
+      tags: tags
+    }
+  }
+]

--- a/modules/scanning-environment/scanningForMg.bicep
+++ b/modules/scanning-environment/scanningForMg.bicep
@@ -63,7 +63,7 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
 @description('Role definition ID for subscription access role from management group scope.')
-param subscriptionAccessRoleId string = ''
+param accessRoleId string = ''
 
 @description('Role definition ID for scanner role from management group scope.')
 param scannerRoleId string = ''
@@ -98,7 +98,7 @@ module scanningSub 'scanningSubBatch.bicep' = [
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-      subscriptionAccessRoleId: subscriptionAccessRoleId
+      accessRoleId: accessRoleId
       scannerRoleId: scannerRoleId
       resourceGroupAccessRoleId: resourceGroupAccessRoleId
       resourceGroupName: resourceGroupName

--- a/modules/scanning-environment/scanningForSub.bicep
+++ b/modules/scanning-environment/scanningForSub.bicep
@@ -138,6 +138,7 @@ resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (
   }
 }
 
+// Custom VNet role applies only to the host subscription (single sub) — no need for MG-scoped definition
 resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (useCustomSubnets) {
   name: guid(subscription().id, 'customVnetSubnetAccess')
   properties: {

--- a/modules/scanning-environment/scanningForSub.bicep
+++ b/modules/scanning-environment/scanningForSub.bicep
@@ -1,7 +1,3 @@
-import {
-  customVnetSubnetRolePermissions
-} from '../../models/scanning-roles.bicep'
-
 targetScope = 'subscription'
 
 /*
@@ -73,14 +69,12 @@ param scannerRoleId string
 @description('Role definition ID for resource group access role (created externally at MG or subscription scope).')
 param resourceGroupAccessRoleId string
 
+@description('Role definition ID for custom VNet subnet access role (created externally at subscription scope). Empty when custom subnets are not used.')
+param customVnetSubnetRoleId string = ''
+
 /* Variables */
-var useCustomSubnets = length(filter(
-  scanningEnvironmentLocations,
-  location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
-)) > 0
 var environment = length(env) > 0 ? '-${env}' : env
 var shouldDeployResources = empty(agentlessScanningHostSubscriptionId) || subscription().subscriptionId == agentlessScanningHostSubscriptionId
-var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${subscription().subscriptionId}${resourceNameSuffix}'
 
 /* Role Assignments */
 resource accessRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
@@ -89,27 +83,6 @@ resource accessRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-0
     roleDefinitionId: accessRoleId
     principalId: scanningPrincipalId
     principalType: 'ServicePrincipal'
-  }
-}
-
-// Custom VNet role applies only to the host subscription (single sub) — no need for MG-scoped definition
-resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (useCustomSubnets) {
-  name: guid(subscription().id, 'customVnetSubnetAccess')
-  properties: {
-    roleName: customVnetRoleName
-    description: customVnetSubnetRolePermissions.description
-    type: 'CustomRole'
-    permissions: [
-      {
-        actions: customVnetSubnetRolePermissions.actions
-        notActions: []
-        dataActions: []
-        notDataActions: []
-      }
-    ]
-    assignableScopes: [
-      subscription().id
-    ]
   }
 }
 
@@ -156,7 +129,7 @@ module scanningRegion 'scanningRegion.bicep' = [
       customScannersSubnet: location.customScannersSubnet
       customClonesSubnet: location.customClonesSubnet
       scanningPrincipalId: scanningPrincipalId
-      customVnetSubnetRoleId: useCustomSubnets ? customVnetSubnetRole.id : ''
+      customVnetSubnetRoleId: customVnetSubnetRoleId
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix
       env: env

--- a/modules/scanning-environment/scanningForSub.bicep
+++ b/modules/scanning-environment/scanningForSub.bicep
@@ -1,8 +1,14 @@
+import {
+  subscriptionAccessRolePermissions
+  scannerRolePermissions
+  customVnetSubnetRolePermissions
+} from '../../models/scanning-roles.bicep'
+
 targetScope = 'subscription'
 
 /*
   This Bicep template deploys infrastructure to enable CrowdStrike Scanning in subscription
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */
@@ -58,7 +64,17 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 @description('Per-region custom VNet configuration for agentless scanning.')
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
+@description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
+param subscriptionAccessRoleId string = ''
+
+@description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
+param scannerRoleId string = ''
+
+@description('Role definition ID for resource group access role. When provided, skips per-subscription role creation (management group mode).')
+param resourceGroupAccessRoleId string = ''
+
 /* Variables */
+var useExternalRoles = !empty(subscriptionAccessRoleId)
 var useCustomSubnets = length(filter(
   scanningEnvironmentLocations,
   location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
@@ -66,29 +82,18 @@ var useCustomSubnets = length(filter(
 var environment = length(env) > 0 ? '-${env}' : env
 var shouldDeployResources = empty(agentlessScanningHostSubscriptionId) || subscription().subscriptionId == agentlessScanningHostSubscriptionId
 var subscriptionAccessRoleName = '${resourceNamePrefix}role-csscanning-access-${subscription().subscriptionId}${resourceNameSuffix}'
-var subscriptionAccessRoleDescription = 'CrowdStrike Scanning Subscription Access Role'
 var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${subscription().subscriptionId}${resourceNameSuffix}'
-var scannerRoleDescription = 'CrowdStrike Scanning Subscription Scanner Role'
 var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${subscription().subscriptionId}${resourceNameSuffix}'
-var customVnetRoleDescription = 'CrowdStrike Custom VNet Subnet Access Role'
 
-resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (!useExternalRoles) {
   name: guid(subscription().id, subscriptionAccessRoleName)
   properties: {
     roleName: subscriptionAccessRoleName
-    description: subscriptionAccessRoleDescription
+    description: subscriptionAccessRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
-        actions: [
-          // ============ Blob Storage ============
-          'Microsoft.Storage/storageAccounts/read' // Check location and public access
-          'Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action' // Approve private link connections
-
-          // ============ Validation ============
-          'Microsoft.Authorization/roleAssignments/read'
-          'Microsoft.Authorization/policyDefinitions/read'
-        ]
+        actions: subscriptionAccessRolePermissions.actions
         notActions: []
         dataActions: []
         notDataActions: []
@@ -101,29 +106,29 @@ resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04
 }
 
 resource accessRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, scanningPrincipalId, subscriptionAccessRole.id)
+  name: guid(
+    subscription().id,
+    scanningPrincipalId,
+    useExternalRoles ? subscriptionAccessRoleId : subscriptionAccessRole.id
+  )
   properties: {
-    roleDefinitionId: subscriptionAccessRole.id
+    roleDefinitionId: useExternalRoles ? subscriptionAccessRoleId : subscriptionAccessRole.id
     principalId: scanningPrincipalId
     principalType: 'ServicePrincipal'
   }
 }
 
-resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (!useExternalRoles) {
   name: guid(subscription().id, scannerRoleName)
   properties: {
     roleName: scannerRoleName
-    description: scannerRoleDescription
+    description: scannerRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
-        actions: [
-          'Microsoft.Storage/storageAccounts/blobServices/containers/read'
-        ]
+        actions: scannerRolePermissions.actions
         notActions: []
-        dataActions: [
-          'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'
-        ]
+        dataActions: scannerRolePermissions.dataActions
         notDataActions: []
       }
     ]
@@ -137,15 +142,11 @@ resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-0
   name: guid(subscription().id, 'customVnetSubnetAccess')
   properties: {
     roleName: customVnetRoleName
-    description: customVnetRoleDescription
+    description: customVnetSubnetRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
-        actions: [
-          'Microsoft.Network/virtualNetworks/subnets/join/action'
-          'Microsoft.Network/virtualNetworks/read'
-          'Microsoft.Network/virtualNetworks/subnets/read'
-        ]
+        actions: customVnetSubnetRolePermissions.actions
         notActions: []
         dataActions: []
         notDataActions: []
@@ -169,6 +170,7 @@ module scanningResourceGroupModule 'scanningResourceGroup.bicep' = if (shouldDep
     falconClientSecret: falconClientSecret
     scanningPrincipalId: scanningPrincipalId
     agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    resourceGroupAccessRoleId: resourceGroupAccessRoleId
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
     env: env
@@ -176,16 +178,18 @@ module scanningResourceGroupModule 'scanningResourceGroup.bicep' = if (shouldDep
   }
 }
 
+var effectiveScannerRoleId = useExternalRoles ? scannerRoleId : scannerRole.id
+
 resource scannerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: shouldDeployResources
-    ? guid(subscription().id, 'scanningManagedIdentityPrincipalId', scannerRole.id)
-    : guid(subscription().id, scanningManagedIdentityPrincipalId, scannerRole.id)
+    ? guid(subscription().id, 'scanningManagedIdentityPrincipalId', effectiveScannerRoleId)
+    : guid(subscription().id, scanningManagedIdentityPrincipalId, effectiveScannerRoleId)
   properties: {
     principalId: shouldDeployResources
       ? scanningResourceGroupModule!.outputs.scanningManagedIdentityPrincipalId
       : scanningManagedIdentityPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: scannerRole.id
+    roleDefinitionId: effectiveScannerRoleId
   }
 }
 

--- a/modules/scanning-environment/scanningForSub.bicep
+++ b/modules/scanning-environment/scanningForSub.bicep
@@ -1,5 +1,5 @@
 import {
-  subscriptionAccessRolePermissions
+  accessRolePermissions
   scannerRolePermissions
   customVnetSubnetRolePermissions
 } from '../../models/scanning-roles.bicep'
@@ -65,7 +65,7 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
 @description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
-param subscriptionAccessRoleId string = ''
+param accessRoleId string = ''
 
 @description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
 param scannerRoleId string = ''
@@ -74,7 +74,7 @@ param scannerRoleId string = ''
 param resourceGroupAccessRoleId string = ''
 
 /* Variables */
-var useExternalRoles = !empty(subscriptionAccessRoleId)
+var useExternalRoles = !empty(accessRoleId)
 var useCustomSubnets = length(filter(
   scanningEnvironmentLocations,
   location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
@@ -89,11 +89,11 @@ resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04
   name: guid(subscription().id, subscriptionAccessRoleName)
   properties: {
     roleName: subscriptionAccessRoleName
-    description: subscriptionAccessRolePermissions.description
+    description: accessRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
-        actions: subscriptionAccessRolePermissions.actions
+        actions: accessRolePermissions.actions
         notActions: []
         dataActions: []
         notDataActions: []
@@ -106,13 +106,9 @@ resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04
 }
 
 resource accessRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(
-    subscription().id,
-    scanningPrincipalId,
-    useExternalRoles ? subscriptionAccessRoleId : subscriptionAccessRole.id
-  )
+  name: guid(subscription().id, scanningPrincipalId, useExternalRoles ? accessRoleId : subscriptionAccessRole.id)
   properties: {
-    roleDefinitionId: useExternalRoles ? subscriptionAccessRoleId : subscriptionAccessRole.id
+    roleDefinitionId: useExternalRoles ? accessRoleId : subscriptionAccessRole.id
     principalId: scanningPrincipalId
     principalType: 'ServicePrincipal'
   }

--- a/modules/scanning-environment/scanningForSub.bicep
+++ b/modules/scanning-environment/scanningForSub.bicep
@@ -1,13 +1,13 @@
 import {
-  accessRolePermissions
-  scannerRolePermissions
   customVnetSubnetRolePermissions
 } from '../../models/scanning-roles.bicep'
 
 targetScope = 'subscription'
 
 /*
-  This Bicep template deploys infrastructure to enable CrowdStrike Scanning in subscription
+  This Bicep template deploys scanning infrastructure in a subscription: role assignments,
+  resource group resources, and scanning regions. Role definitions are created externally
+  (at management group or subscription scope) and passed in via parameters.
   Copyright (c) 2026 CrowdStrike, Inc.
 */
 
@@ -64,73 +64,31 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 @description('Per-region custom VNet configuration for agentless scanning.')
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
-@description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
-param accessRoleId string = ''
+@description('Role definition ID for access role (created externally at MG or subscription scope).')
+param accessRoleId string
 
-@description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
-param scannerRoleId string = ''
+@description('Role definition ID for scanner role (created externally at MG or subscription scope).')
+param scannerRoleId string
 
-@description('Role definition ID for resource group access role. When provided, skips per-subscription role creation (management group mode).')
-param resourceGroupAccessRoleId string = ''
+@description('Role definition ID for resource group access role (created externally at MG or subscription scope).')
+param resourceGroupAccessRoleId string
 
 /* Variables */
-var useExternalRoles = !empty(accessRoleId)
 var useCustomSubnets = length(filter(
   scanningEnvironmentLocations,
   location => !empty(location.customScannersSubnet) && !empty(location.customClonesSubnet)
 )) > 0
 var environment = length(env) > 0 ? '-${env}' : env
 var shouldDeployResources = empty(agentlessScanningHostSubscriptionId) || subscription().subscriptionId == agentlessScanningHostSubscriptionId
-var subscriptionAccessRoleName = '${resourceNamePrefix}role-csscanning-access-${subscription().subscriptionId}${resourceNameSuffix}'
-var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${subscription().subscriptionId}${resourceNameSuffix}'
 var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${subscription().subscriptionId}${resourceNameSuffix}'
 
-resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (!useExternalRoles) {
-  name: guid(subscription().id, subscriptionAccessRoleName)
-  properties: {
-    roleName: subscriptionAccessRoleName
-    description: accessRolePermissions.description
-    type: 'CustomRole'
-    permissions: [
-      {
-        actions: accessRolePermissions.actions
-        notActions: []
-        dataActions: []
-        notDataActions: []
-      }
-    ]
-    assignableScopes: [
-      subscription().id
-    ]
-  }
-}
-
+/* Role Assignments */
 resource accessRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, scanningPrincipalId, useExternalRoles ? accessRoleId : subscriptionAccessRole.id)
+  name: guid(subscription().id, scanningPrincipalId, accessRoleId)
   properties: {
-    roleDefinitionId: useExternalRoles ? accessRoleId : subscriptionAccessRole.id
+    roleDefinitionId: accessRoleId
     principalId: scanningPrincipalId
     principalType: 'ServicePrincipal'
-  }
-}
-
-resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (!useExternalRoles) {
-  name: guid(subscription().id, scannerRoleName)
-  properties: {
-    roleName: scannerRoleName
-    description: scannerRolePermissions.description
-    type: 'CustomRole'
-    permissions: [
-      {
-        actions: scannerRolePermissions.actions
-        notActions: []
-        dataActions: scannerRolePermissions.dataActions
-        notDataActions: []
-      }
-    ]
-    assignableScopes: [
-      subscription().id
-    ]
   }
 }
 
@@ -155,6 +113,7 @@ resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-0
   }
 }
 
+/* Resource Group Deployment */
 resource scanningResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' existing = {
   name: resourceGroupName
 }
@@ -175,18 +134,16 @@ module scanningResourceGroupModule 'scanningResourceGroup.bicep' = if (shouldDep
   }
 }
 
-var effectiveScannerRoleId = useExternalRoles ? scannerRoleId : scannerRole.id
-
 resource scannerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: shouldDeployResources
-    ? guid(subscription().id, 'scanningManagedIdentityPrincipalId', effectiveScannerRoleId)
-    : guid(subscription().id, scanningManagedIdentityPrincipalId, effectiveScannerRoleId)
+    ? guid(subscription().id, 'scanningManagedIdentityPrincipalId', scannerRoleId)
+    : guid(subscription().id, scanningManagedIdentityPrincipalId, scannerRoleId)
   properties: {
     principalId: shouldDeployResources
       ? scanningResourceGroupModule!.outputs.scanningManagedIdentityPrincipalId
       : scanningManagedIdentityPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: effectiveScannerRoleId
+    roleDefinitionId: scannerRoleId
   }
 }
 

--- a/modules/scanning-environment/scanningKeyVaultPrivateEndpoint.bicep
+++ b/modules/scanning-environment/scanningKeyVaultPrivateEndpoint.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 /*
   This Bicep template deploys private endpoint connecting key vault to subnet in the scanning environment
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */

--- a/modules/scanning-environment/scanningParameters.bicep
+++ b/modules/scanning-environment/scanningParameters.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 /*
   This Bicep template deploys a policy definition to store scanning parameters
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */

--- a/modules/scanning-environment/scanningRegion.bicep
+++ b/modules/scanning-environment/scanningRegion.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 /*
   This Bicep template deploys regional resources of the scanning environment
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */

--- a/modules/scanning-environment/scanningResourceGroup.bicep
+++ b/modules/scanning-environment/scanningResourceGroup.bicep
@@ -55,12 +55,10 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
     type: 'CustomRole'
     permissions: [
       {
-        actions: !agentlessScanningDeployNatGateway
-          ? union(
-              resourceGroupAccessRolePermissions.actions,
-              resourceGroupAccessRolePermissions.conditionalPublicIPActions
-            )
-          : resourceGroupAccessRolePermissions.actions
+        actions: union(
+          resourceGroupAccessRolePermissions.actions,
+          !agentlessScanningDeployNatGateway ? resourceGroupAccessRolePermissions.conditionalPublicIPActions : []
+        )
         notActions: []
         dataActions: []
         notDataActions: []

--- a/modules/scanning-environment/scanningResourceGroup.bicep
+++ b/modules/scanning-environment/scanningResourceGroup.bicep
@@ -1,8 +1,10 @@
+import { resourceGroupAccessRolePermissions } from '../../models/scanning-roles.bicep'
+
 targetScope = 'resourceGroup'
 
 /*
   This Bicep template deploys resource group level scanning resources
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */
@@ -33,73 +35,32 @@ param tags object
 @description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
 param agentlessScanningDeployNatGateway bool = true
 
+@description('Role definition ID for resource group access role. When provided, skips per-subscription role creation (management group mode).')
+param resourceGroupAccessRoleId string = ''
+
 /* Variables */
+var useExternalRgRole = !empty(resourceGroupAccessRoleId)
 var environment = length(env) > 0 ? '-${env}' : env
 // NOTE: key vault has name limit constraints, so prefix and suffix are omitted 
 var keyVaultName = 'kv-cs-${uniqueString(resourceGroup().id, 'CrowdStrikeScanningKeyVault', 'v2')}'
 var managedIdentityName = '${resourceNamePrefix}id-csscanning${environment}${resourceNameSuffix}'
 var clientCredentialsName = 'client-credentials'
-var resourceGroupAccessCustomRole = {
-  roleName: '${resourceNamePrefix}role-csscanning-rgaccess-${subscription().subscriptionId}${resourceNameSuffix}'
-  roleDescription: 'CrowdStrike Agentless Scanning Resource Group Access Role'
-  roleActions: [
-    // ============ Blob Storage ============
-    // Private Endpoint
-    'Microsoft.Network/privateEndpoints/read'
-    'Microsoft.Network/privateEndpoints/write'
-    'Microsoft.Network/privateEndpoints/delete'
-    'Microsoft.Network/virtualNetworks/subnets/join/action'
+var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${subscription().subscriptionId}${resourceNameSuffix}'
 
-    // ============ Scanner VM ============
-    'Microsoft.Network/networkSecurityGroups/read'
-    'Microsoft.Network/networkSecurityGroups/write'
-    'Microsoft.Network/networkSecurityGroups/delete'
-    'Microsoft.Network/networkInterfaces/read'
-    'Microsoft.Network/networkInterfaces/write'
-    'Microsoft.Network/networkInterfaces/delete'
-    'Microsoft.Network/networkInterfaces/join/action'
-    'Microsoft.Compute/virtualMachines/read'
-    'Microsoft.Compute/virtualMachines/write'
-    'Microsoft.Compute/virtualMachines/delete'
-    'Microsoft.Network/virtualNetworks/read'
-    'Microsoft.ManagedIdentity/userAssignedIdentities/read'
-    'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
-    'Microsoft.Resources/deployments/read'
-    'Microsoft.Resources/deployments/write'
-    'Microsoft.Resources/deployments/delete'
-    'Microsoft.Resources/deployments/operationStatuses/read'
-    'Microsoft.Resources/deploymentStacks/*'
-    // Always include delete permission for public IPs
-    'Microsoft.Network/publicIPAddresses/delete'
-
-    // ============ Validation ============
-    'Microsoft.Network/virtualNetworks/subnets/read'
-    'Microsoft.Resources/deployments/whatIf/action'
-    'Microsoft.Resources/deployments/validate/action'
-    'Microsoft.Resources/deploymentScripts/read'
-    'Microsoft.KeyVault/vaults/read'
-    'Microsoft.Compute/virtualMachines/retrieveBootDiagnosticsData/action'
-  ]
-}
-
-// Conditional permissions for public IPs when NAT Gateway is disabled
-var conditionalPublicIPPermissions = [
-  'Microsoft.Network/publicIPAddresses/read'
-  'Microsoft.Network/publicIPAddresses/write'
-  'Microsoft.Network/publicIPAddresses/join/action'
-]
-
-resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(resourceGroup().id, resourceGroupAccessCustomRole.roleName)
+resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (!useExternalRgRole) {
+  name: guid(resourceGroup().id, resourceGroupAccessRoleName)
   properties: {
-    roleName: resourceGroupAccessCustomRole.roleName
-    description: resourceGroupAccessCustomRole.roleDescription
+    roleName: resourceGroupAccessRoleName
+    description: resourceGroupAccessRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
         actions: !agentlessScanningDeployNatGateway
-          ? union(resourceGroupAccessCustomRole.roleActions, conditionalPublicIPPermissions)
-          : resourceGroupAccessCustomRole.roleActions
+          ? union(
+              resourceGroupAccessRolePermissions.actions,
+              resourceGroupAccessRolePermissions.conditionalPublicIPActions
+            )
+          : resourceGroupAccessRolePermissions.actions
         notActions: []
         dataActions: []
         notDataActions: []
@@ -112,9 +73,13 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
 }
 
 resource rgRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, scanningPrincipalId, resourceGroupAccessRole.id)
+  name: guid(
+    subscription().id,
+    scanningPrincipalId,
+    useExternalRgRole ? resourceGroupAccessRoleId : resourceGroupAccessRole.id
+  )
   properties: {
-    roleDefinitionId: resourceGroupAccessRole.id
+    roleDefinitionId: useExternalRgRole ? resourceGroupAccessRoleId : resourceGroupAccessRole.id
     principalId: scanningPrincipalId
     principalType: 'ServicePrincipal'
   }

--- a/modules/scanning-environment/scanningRolesForMg.bicep
+++ b/modules/scanning-environment/scanningRolesForMg.bicep
@@ -22,10 +22,6 @@ param resourceNamePrefix string = ''
 @description('Optional suffix added to all resource names for organization and identification purposes.')
 param resourceNameSuffix string = ''
 
-@maxLength(4)
-@description('Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments.')
-param env string
-
 @description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
 param agentlessScanningDeployNatGateway bool = true
 
@@ -43,7 +39,7 @@ var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${man
 
 /* Role Definitions */
 resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(managementGroup().id, accessRoleName, env)
+  name: guid(managementGroup().id, accessRoleName)
   properties: {
     roleName: accessRoleName
     description: accessRolePermissions.description
@@ -63,7 +59,7 @@ resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
 }
 
 resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(managementGroup().id, scannerRoleName, env)
+  name: guid(managementGroup().id, scannerRoleName)
   properties: {
     roleName: scannerRoleName
     description: scannerRolePermissions.description
@@ -83,7 +79,7 @@ resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
 }
 
 resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (includeResourceGroupAccessRole) {
-  name: guid(managementGroup().id, resourceGroupAccessRoleName, env)
+  name: guid(managementGroup().id, resourceGroupAccessRoleName)
   properties: {
     roleName: resourceGroupAccessRoleName
     description: resourceGroupAccessRolePermissions.description

--- a/modules/scanning-environment/scanningRolesForMg.bicep
+++ b/modules/scanning-environment/scanningRolesForMg.bicep
@@ -8,7 +8,7 @@ targetScope = 'managementGroup'
 
 /*
   This Bicep template defines custom role definitions at management group scope
-  for CrowdStrike Scanning, reducing the number of custom roles consumed per tenant.
+  for CrowdStrike Scanning.
   Copyright (c) 2026 CrowdStrike, Inc.
 */
 

--- a/modules/scanning-environment/scanningRolesForMg.bicep
+++ b/modules/scanning-environment/scanningRolesForMg.bicep
@@ -2,6 +2,7 @@ import {
   accessRolePermissions
   scannerRolePermissions
   resourceGroupAccessRolePermissions
+  customVnetSubnetRolePermissions
 } from '../../models/scanning-roles.bicep'
 
 targetScope = 'managementGroup'
@@ -28,10 +29,17 @@ param env string
 @description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
 param agentlessScanningDeployNatGateway bool = true
 
+@description('Whether to create the resource group access role definition. Only needed for the MG containing the host subscription.')
+param includeResourceGroupAccessRole bool = true
+
+@description('Whether custom VNet subnets are used. When true, creates the custom VNet subnet access role.')
+param useCustomSubnets bool = false
+
 /* Variables */
 var accessRoleName = '${resourceNamePrefix}role-csscanning-access-${managementGroup().name}${resourceNameSuffix}'
 var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${managementGroup().name}${resourceNameSuffix}'
 var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${managementGroup().name}${resourceNameSuffix}'
+var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${managementGroup().name}${resourceNameSuffix}'
 
 /* Role Definitions */
 resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
@@ -74,7 +82,7 @@ resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
   }
 }
 
-resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (includeResourceGroupAccessRole) {
   name: guid(managementGroup().id, resourceGroupAccessRoleName, env)
   properties: {
     roleName: resourceGroupAccessRoleName
@@ -97,7 +105,28 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
   }
 }
 
+resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (useCustomSubnets) {
+  name: guid(managementGroup().id, 'customVnetSubnetAccess')
+  properties: {
+    roleName: customVnetRoleName
+    description: customVnetSubnetRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: customVnetSubnetRolePermissions.actions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      managementGroup().id
+    ]
+  }
+}
+
 /* Outputs */
 output accessRoleId string = accessRole.id
 output scannerRoleId string = scannerRole.id
-output resourceGroupAccessRoleId string = resourceGroupAccessRole.id
+output resourceGroupAccessRoleId string = includeResourceGroupAccessRole ? resourceGroupAccessRole.id : ''
+output customVnetSubnetRoleId string = useCustomSubnets ? customVnetSubnetRole.id : ''

--- a/modules/scanning-environment/scanningRolesForMg.bicep
+++ b/modules/scanning-environment/scanningRolesForMg.bicep
@@ -1,5 +1,5 @@
 import {
-  subscriptionAccessRolePermissions
+  accessRolePermissions
   scannerRolePermissions
   resourceGroupAccessRolePermissions
 } from '../../models/scanning-roles.bicep'
@@ -29,20 +29,20 @@ param env string
 param agentlessScanningDeployNatGateway bool = true
 
 /* Variables */
-var subscriptionAccessRoleName = '${resourceNamePrefix}role-csscanning-access-${managementGroup().name}${resourceNameSuffix}'
+var accessRoleName = '${resourceNamePrefix}role-csscanning-access-${managementGroup().name}${resourceNameSuffix}'
 var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${managementGroup().name}${resourceNameSuffix}'
 var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${managementGroup().name}${resourceNameSuffix}'
 
 /* Role Definitions */
-resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(managementGroup().id, subscriptionAccessRoleName, env)
+resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(managementGroup().id, accessRoleName, env)
   properties: {
-    roleName: subscriptionAccessRoleName
-    description: subscriptionAccessRolePermissions.description
+    roleName: accessRoleName
+    description: accessRolePermissions.description
     type: 'CustomRole'
     permissions: [
       {
-        actions: subscriptionAccessRolePermissions.actions
+        actions: accessRolePermissions.actions
         notActions: []
         dataActions: []
         notDataActions: []
@@ -82,12 +82,10 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
     type: 'CustomRole'
     permissions: [
       {
-        actions: !agentlessScanningDeployNatGateway
-          ? union(
-              resourceGroupAccessRolePermissions.actions,
-              resourceGroupAccessRolePermissions.conditionalPublicIPActions
-            )
-          : resourceGroupAccessRolePermissions.actions
+        actions: union(
+          resourceGroupAccessRolePermissions.actions,
+          !agentlessScanningDeployNatGateway ? resourceGroupAccessRolePermissions.conditionalPublicIPActions : []
+        )
         notActions: []
         dataActions: []
         notDataActions: []
@@ -100,6 +98,6 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
 }
 
 /* Outputs */
-output subscriptionAccessRoleId string = subscriptionAccessRole.id
+output accessRoleId string = accessRole.id
 output scannerRoleId string = scannerRole.id
 output resourceGroupAccessRoleId string = resourceGroupAccessRole.id

--- a/modules/scanning-environment/scanningRolesForMg.bicep
+++ b/modules/scanning-environment/scanningRolesForMg.bicep
@@ -1,0 +1,105 @@
+import {
+  subscriptionAccessRolePermissions
+  scannerRolePermissions
+  resourceGroupAccessRolePermissions
+} from '../../models/scanning-roles.bicep'
+
+targetScope = 'managementGroup'
+
+/*
+  This Bicep template defines custom role definitions at management group scope
+  for CrowdStrike Scanning, reducing the number of custom roles consumed per tenant.
+  Copyright (c) 2026 CrowdStrike, Inc.
+*/
+
+/* Parameters */
+@maxLength(10)
+@description('Optional prefix added to all resource names for organization and identification purposes.')
+param resourceNamePrefix string = ''
+
+@maxLength(10)
+@description('Optional suffix added to all resource names for organization and identification purposes.')
+param resourceNameSuffix string = ''
+
+@maxLength(4)
+@description('Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments.')
+param env string
+
+@description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
+param agentlessScanningDeployNatGateway bool = true
+
+/* Variables */
+var subscriptionAccessRoleName = '${resourceNamePrefix}role-csscanning-access-${managementGroup().name}${resourceNameSuffix}'
+var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${managementGroup().name}${resourceNameSuffix}'
+var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${managementGroup().name}${resourceNameSuffix}'
+
+/* Role Definitions */
+resource subscriptionAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(managementGroup().id, subscriptionAccessRoleName, env)
+  properties: {
+    roleName: subscriptionAccessRoleName
+    description: subscriptionAccessRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: subscriptionAccessRolePermissions.actions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      managementGroup().id
+    ]
+  }
+}
+
+resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(managementGroup().id, scannerRoleName, env)
+  properties: {
+    roleName: scannerRoleName
+    description: scannerRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: scannerRolePermissions.actions
+        notActions: []
+        dataActions: scannerRolePermissions.dataActions
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      managementGroup().id
+    ]
+  }
+}
+
+resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(managementGroup().id, resourceGroupAccessRoleName, env)
+  properties: {
+    roleName: resourceGroupAccessRoleName
+    description: resourceGroupAccessRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: !agentlessScanningDeployNatGateway
+          ? union(
+              resourceGroupAccessRolePermissions.actions,
+              resourceGroupAccessRolePermissions.conditionalPublicIPActions
+            )
+          : resourceGroupAccessRolePermissions.actions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      managementGroup().id
+    ]
+  }
+}
+
+/* Outputs */
+output subscriptionAccessRoleId string = subscriptionAccessRole.id
+output scannerRoleId string = scannerRole.id
+output resourceGroupAccessRoleId string = resourceGroupAccessRole.id

--- a/modules/scanning-environment/scanningRolesForSub.bicep
+++ b/modules/scanning-environment/scanningRolesForSub.bicep
@@ -1,0 +1,103 @@
+import {
+  accessRolePermissions
+  scannerRolePermissions
+  resourceGroupAccessRolePermissions
+} from '../../models/scanning-roles.bicep'
+
+targetScope = 'subscription'
+
+/*
+  This Bicep template defines custom role definitions at subscription scope
+  for CrowdStrike Scanning.
+  Copyright (c) 2026 CrowdStrike, Inc.
+*/
+
+/* Parameters */
+@maxLength(10)
+@description('Optional prefix added to all resource names for organization and identification purposes.')
+param resourceNamePrefix string = ''
+
+@maxLength(10)
+@description('Optional suffix added to all resource names for organization and identification purposes.')
+param resourceNameSuffix string = ''
+
+@maxLength(4)
+@description('Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments.')
+param env string
+
+@description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
+param agentlessScanningDeployNatGateway bool = true
+
+/* Variables */
+var accessRoleName = '${resourceNamePrefix}role-csscanning-access-${subscription().subscriptionId}${resourceNameSuffix}'
+var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${subscription().subscriptionId}${resourceNameSuffix}'
+var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${subscription().subscriptionId}${resourceNameSuffix}'
+
+/* Role Definitions */
+resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(subscription().id, accessRoleName, env)
+  properties: {
+    roleName: accessRoleName
+    description: accessRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: accessRolePermissions.actions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(subscription().id, scannerRoleName, env)
+  properties: {
+    roleName: scannerRoleName
+    description: scannerRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: scannerRolePermissions.actions
+        notActions: []
+        dataActions: scannerRolePermissions.dataActions
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(subscription().id, resourceGroupAccessRoleName, env)
+  properties: {
+    roleName: resourceGroupAccessRoleName
+    description: resourceGroupAccessRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: union(
+          resourceGroupAccessRolePermissions.actions,
+          !agentlessScanningDeployNatGateway ? resourceGroupAccessRolePermissions.conditionalPublicIPActions : []
+        )
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+/* Outputs */
+output accessRoleId string = accessRole.id
+output scannerRoleId string = scannerRole.id
+output resourceGroupAccessRoleId string = resourceGroupAccessRole.id

--- a/modules/scanning-environment/scanningRolesForSub.bicep
+++ b/modules/scanning-environment/scanningRolesForSub.bicep
@@ -2,6 +2,7 @@ import {
   accessRolePermissions
   scannerRolePermissions
   resourceGroupAccessRolePermissions
+  customVnetSubnetRolePermissions
 } from '../../models/scanning-roles.bicep'
 
 targetScope = 'subscription'
@@ -28,10 +29,17 @@ param env string
 @description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
 param agentlessScanningDeployNatGateway bool = true
 
+@description('Whether to create the resource group access role definition. Only needed for the host subscription.')
+param includeResourceGroupAccessRole bool = true
+
+@description('Whether custom VNet subnets are used. When true, creates the custom VNet subnet access role.')
+param useCustomSubnets bool = false
+
 /* Variables */
 var accessRoleName = '${resourceNamePrefix}role-csscanning-access-${subscription().subscriptionId}${resourceNameSuffix}'
 var scannerRoleName = '${resourceNamePrefix}role-csscanning-scanner-${subscription().subscriptionId}${resourceNameSuffix}'
 var resourceGroupAccessRoleName = '${resourceNamePrefix}role-csscanning-rgaccess-${subscription().subscriptionId}${resourceNameSuffix}'
+var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${subscription().subscriptionId}${resourceNameSuffix}'
 
 /* Role Definitions */
 resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
@@ -74,7 +82,7 @@ resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
   }
 }
 
-resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (includeResourceGroupAccessRole) {
   name: guid(subscription().id, resourceGroupAccessRoleName, env)
   properties: {
     roleName: resourceGroupAccessRoleName
@@ -97,7 +105,29 @@ resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-0
   }
 }
 
+// Custom VNet role applies only to the host subscription (single sub) — no need for MG-scoped definition
+resource customVnetSubnetRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (useCustomSubnets) {
+  name: guid(subscription().id, 'customVnetSubnetAccess')
+  properties: {
+    roleName: customVnetRoleName
+    description: customVnetSubnetRolePermissions.description
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: customVnetSubnetRolePermissions.actions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
 /* Outputs */
 output accessRoleId string = accessRole.id
 output scannerRoleId string = scannerRole.id
-output resourceGroupAccessRoleId string = resourceGroupAccessRole.id
+output resourceGroupAccessRoleId string = includeResourceGroupAccessRole ? resourceGroupAccessRole.id : ''
+output customVnetSubnetRoleId string = useCustomSubnets ? customVnetSubnetRole.id : ''

--- a/modules/scanning-environment/scanningRolesForSub.bicep
+++ b/modules/scanning-environment/scanningRolesForSub.bicep
@@ -22,10 +22,6 @@ param resourceNamePrefix string = ''
 @description('Optional suffix added to all resource names for organization and identification purposes.')
 param resourceNameSuffix string = ''
 
-@maxLength(4)
-@description('Environment label (for example, prod, stag, dev) used for resource naming and tagging. Helps distinguish between different deployment environments.')
-param env string
-
 @description('Whether NAT Gateway is enabled. When false, public IP permissions are included for VM connectivity.')
 param agentlessScanningDeployNatGateway bool = true
 
@@ -43,7 +39,7 @@ var customVnetRoleName = '${resourceNamePrefix}role-csscanning-custom-vnet-${sub
 
 /* Role Definitions */
 resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(subscription().id, accessRoleName, env)
+  name: guid(subscription().id, accessRoleName)
   properties: {
     roleName: accessRoleName
     description: accessRolePermissions.description
@@ -63,7 +59,7 @@ resource accessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
 }
 
 resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
-  name: guid(subscription().id, scannerRoleName, env)
+  name: guid(subscription().id, scannerRoleName)
   properties: {
     roleName: scannerRoleName
     description: scannerRolePermissions.description
@@ -83,7 +79,7 @@ resource scannerRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
 }
 
 resource resourceGroupAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (includeResourceGroupAccessRole) {
-  name: guid(subscription().id, resourceGroupAccessRoleName, env)
+  name: guid(subscription().id, resourceGroupAccessRoleName)
   properties: {
     roleName: resourceGroupAccessRoleName
     description: resourceGroupAccessRolePermissions.description

--- a/modules/scanning-environment/scanningSubBatch.bicep
+++ b/modules/scanning-environment/scanningSubBatch.bicep
@@ -60,21 +60,36 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 @description('Per-region custom VNet configuration for agentless scanning.')
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
-@description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
+@description('Role definition ID for access role. When provided, uses MG-scoped role instead of creating per-subscription.')
 param accessRoleId string = ''
 
-@description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
+@description('Role definition ID for scanner role. When provided, uses MG-scoped role instead of creating per-subscription.')
 param scannerRoleId string = ''
 
-@description('Role definition ID for resource group access role. When provided, skips per-subscription role creation (management group mode).')
+@description('Role definition ID for resource group access role. When provided, uses MG-scoped role instead of creating per-subscription.')
 param resourceGroupAccessRoleId string = ''
 
 /* Variables */
 var environment = length(env) > 0 ? '-${env}' : env
+var useExternalRoles = !empty(accessRoleId)
+
+/* Create per-subscription roles when no MG-scoped roles are provided */
+module subRoles 'scanningRolesForSub.bicep' = [
+  for sub in subscriptionEntries: if (!useExternalRoles) {
+    name: '${resourceNamePrefix}cs-scanning-roles-${uniqueString(sub.subscriptionId)}${environment}${resourceNameSuffix}'
+    scope: subscription(sub.subscriptionId)
+    params: {
+      resourceNamePrefix: resourceNamePrefix
+      resourceNameSuffix: resourceNameSuffix
+      env: env
+      agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+    }
+  }
+]
 
 /* Deploy scanning infrastructure for subscriptions in this batch */
 module scanningSub 'scanningForSub.bicep' = [
-  for sub in subscriptionEntries: {
+  for (sub, i) in subscriptionEntries: {
     name: '${resourceNamePrefix}cs-scanning-${sub.subscriptionId}${environment}${resourceNameSuffix}'
     scope: subscription(sub.subscriptionId)
     params: {
@@ -89,9 +104,11 @@ module scanningSub 'scanningForSub.bicep' = [
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-      accessRoleId: accessRoleId
-      scannerRoleId: scannerRoleId
-      resourceGroupAccessRoleId: resourceGroupAccessRoleId
+      accessRoleId: useExternalRoles ? accessRoleId : subRoles[i]!.outputs.accessRoleId
+      scannerRoleId: useExternalRoles ? scannerRoleId : subRoles[i]!.outputs.scannerRoleId
+      resourceGroupAccessRoleId: useExternalRoles
+        ? resourceGroupAccessRoleId
+        : subRoles[i]!.outputs.resourceGroupAccessRoleId
       resourceGroupName: resourceGroupName
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix

--- a/modules/scanning-environment/scanningSubBatch.bicep
+++ b/modules/scanning-environment/scanningSubBatch.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 /*
   This Bicep template handles batched scanning subscription deployment
   to overcome the 800 iteration limit for large numbers of subscriptions.
-  Copyright (c) 2025 CrowdStrike, Inc.
+  Copyright (c) 2026 CrowdStrike, Inc.
 */
 
 /* Parameters */
@@ -60,6 +60,15 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 @description('Per-region custom VNet configuration for agentless scanning.')
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
+@description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
+param subscriptionAccessRoleId string = ''
+
+@description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
+param scannerRoleId string = ''
+
+@description('Role definition ID for resource group access role. When provided, skips per-subscription role creation (management group mode).')
+param resourceGroupAccessRoleId string = ''
+
 /* Variables */
 var environment = length(env) > 0 ? '-${env}' : env
 
@@ -80,6 +89,9 @@ module scanningSub 'scanningForSub.bicep' = [
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
+      subscriptionAccessRoleId: subscriptionAccessRoleId
+      scannerRoleId: scannerRoleId
+      resourceGroupAccessRoleId: resourceGroupAccessRoleId
       resourceGroupName: resourceGroupName
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix

--- a/modules/scanning-environment/scanningSubBatch.bicep
+++ b/modules/scanning-environment/scanningSubBatch.bicep
@@ -84,7 +84,6 @@ module subRoles 'scanningRolesForSub.bicep' = [
     params: {
       resourceNamePrefix: resourceNamePrefix
       resourceNameSuffix: resourceNameSuffix
-      env: env
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
       includeResourceGroupAccessRole: includeResourceGroupAccessRole
     }

--- a/modules/scanning-environment/scanningSubBatch.bicep
+++ b/modules/scanning-environment/scanningSubBatch.bicep
@@ -61,7 +61,7 @@ param inputAgentlessScanningLocationsPerSubscription object = {}
 param inputAgentlessScanningCustomVnetConfiguration object = {}
 
 @description('Role definition ID for subscription access role. When provided, skips per-subscription role creation (management group mode).')
-param subscriptionAccessRoleId string = ''
+param accessRoleId string = ''
 
 @description('Role definition ID for scanner role. When provided, skips per-subscription role creation (management group mode).')
 param scannerRoleId string = ''
@@ -89,7 +89,7 @@ module scanningSub 'scanningForSub.bicep' = [
       inputAgentlessScanningLocations: inputAgentlessScanningLocations
       inputAgentlessScanningLocationsPerSubscription: inputAgentlessScanningLocationsPerSubscription
       inputAgentlessScanningCustomVnetConfiguration: inputAgentlessScanningCustomVnetConfiguration
-      subscriptionAccessRoleId: subscriptionAccessRoleId
+      accessRoleId: accessRoleId
       scannerRoleId: scannerRoleId
       resourceGroupAccessRoleId: resourceGroupAccessRoleId
       resourceGroupName: resourceGroupName

--- a/modules/scanning-environment/scanningSubBatch.bicep
+++ b/modules/scanning-environment/scanningSubBatch.bicep
@@ -69,6 +69,9 @@ param scannerRoleId string = ''
 @description('Role definition ID for resource group access role. When provided, uses MG-scoped role instead of creating per-subscription.')
 param resourceGroupAccessRoleId string = ''
 
+@description('Whether to create the resource group access role definition in per-subscription roles. Only needed for host subscriptions.')
+param includeResourceGroupAccessRole bool = true
+
 /* Variables */
 var environment = length(env) > 0 ? '-${env}' : env
 var useExternalRoles = !empty(accessRoleId)
@@ -83,6 +86,7 @@ module subRoles 'scanningRolesForSub.bicep' = [
       resourceNameSuffix: resourceNameSuffix
       env: env
       agentlessScanningDeployNatGateway: agentlessScanningDeployNatGateway
+      includeResourceGroupAccessRole: includeResourceGroupAccessRole
     }
   }
 ]


### PR DESCRIPTION
reduce num of custom roles for mgs on agentless scanning module

## Test Scenarios for agentless scanning

  | # | Scenario | Mode | Status |
  |---|----------|------|--------|
  | 1 | Tenant per-account | per-account | :white_check_mark: |
  | 2 | Tenant cross-account (host always under root MG) | cross-account | :white_check_mark: |
  | 3 | Multi MGs, empty subs | per-account | :white_check_mark: |
  | 4 | Multi MGs, 2 subs in MGs | per-account | :white_check_mark: |
  | 4b | Multi MGs, host in MG | cross-account | :white_check_mark: |
  | 4c | Multi MGs, host standalone | cross-account | :white_check_mark: |
  | 5 | Multi MGs, 1 in MG + 1 standalone | per-account | :white_check_mark: |
  | 5b | Multi MGs + 1 in MG + host is the standalone | cross-account | :white_check_mark: |
  | 6 | Subs only (no MGs) | per-account | :white_check_mark: |
  | 6b | Subs only, cross-account (host standalone) | cross-account | :white_check_mark: |