### PR TITLE
feat(azure-bicep-cloud-registration): CSPG-91459 Add 7 new Entra ID diagnostic log categories

### DIFF
--- a/modules/log-ingestion/entraLog.bicep
+++ b/modules/log-ingestion/entraLog.bicep
@@ -79,6 +79,62 @@ resource entraDiagnosticSettings 'microsoft.aadiam/diagnosticSettings@2017-04-01
           enabled: false
         }
       }
+      {
+        category: 'MicrosoftGraphActivityLogs'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'ProvisioningLogs'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'UserRiskEvents'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'RiskyUsers'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'RiskyServicePrincipals'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'ServicePrincipalRiskEvents'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
+      {
+        category: 'NetworkAccessTraffic'
+        enabled: true
+        retentionPolicy: {
+          days: 0
+          enabled: false
+        }
+      }
     ]
   }
 }

--- a/modules/log-ingestion/entraLog.bicep
+++ b/modules/log-ingestion/entraLog.bicep
@@ -128,7 +128,7 @@ resource entraDiagnosticSettings 'microsoft.aadiam/diagnosticSettings@2017-04-01
         }
       }
       {
-        category: 'NetworkAccessTraffic'
+        category: 'NetworkAccessTrafficLogs'
         enabled: true
         retentionPolicy: {
           days: 0


### PR DESCRIPTION
## Problem
The existing Entra ID diagnostic settings template only collects 6 log categories (AuditLogs, SignInLogs, and sign-in variants). Seven new Entra ID / Global Secure Access log types are required for expanded FCS IOA coverage: identity risk events, provisioning activity, Microsoft Graph API usage, and network access patterns.

## Solution
Added 7 new log category blocks to `modules/log-ingestion/entraLog.bicep` in the `microsoft.aadiam/diagnosticSettings@2017-04-01` resource. The new categories follow the same pattern as existing ones (`enabled: true`, `retentionPolicy: { days: 0, enabled: false }`):

- `MicrosoftGraphActivityLogs`
- `ProvisioningLogs`
- `UserRiskEvents`
- `RiskyUsers`
- `RiskyServicePrincipals`
- `ServicePrincipalRiskEvents`
- `NetworkAccessTraffic`

No new infrastructure is created — logs route to the existing Entra ID Event Hub.

## Configuration
- Entra ID P2 license required for Identity Protection categories (UserRiskEvents, RiskyUsers, RiskyServicePrincipals, ServicePrincipalRiskEvents)
- Microsoft Entra Global Secure Access license required for NetworkAccessTraffic

## Security
No new permissions required beyond existing `Security Administrator` / `Global Administrator` Entra ID role.

## Test Plan
- [ ] Deploy template to a dev tenant and verify all 13 categories appear in the diagnostic settings resource
- [ ] Confirm logs flow through the Entra ID Event Hub for each new category