### PR TITLE
feat(asset-inventory): CSPG-94315 Add resource lock permissions to cu…

### DIFF
--- a/modules/asset-inventory/customRoleForMgmtGroup.bicep
+++ b/modules/asset-inventory/customRoleForMgmtGroup.bicep
@@ -16,12 +16,15 @@ param env string
 
 var customRole = {
   roleName: 'role-csreader'
-  roleDescription: 'CrowdStrike custom role to allow read access to App Service and Function.'
+  roleDescription: 'CrowdStrike custom role to allow read access to App Service and Function, and administer Resource Locks.'
   roleActions: [
     'Microsoft.Web/sites/Read'
     'Microsoft.Web/sites/config/Read'
     'Microsoft.Web/sites/config/list/Action'
     'Microsoft.Web/sites/publish/action'
+    'Microsoft.Authorization/locks/read'
+    'Microsoft.Authorization/locks/write'
+    'Microsoft.Authorization/locks/delete'
   ]
 }
 

--- a/modules/asset-inventory/customRoleForSub.bicep
+++ b/modules/asset-inventory/customRoleForSub.bicep
@@ -15,12 +15,15 @@ param env string
 
 var customRole = {
   roleName: 'role-csreader'
-  roleDescription: 'CrowdStrike custom role to allow read access to App Service and Function.'
+  roleDescription: 'CrowdStrike custom role to allow read access to App Service and Function, and administer Resource Locks.'
   roleActions: [
     'Microsoft.Web/sites/Read'
     'Microsoft.Web/sites/config/Read'
     'Microsoft.Web/sites/config/list/Action'
     'Microsoft.Web/sites/publish/action'
+    'Microsoft.Authorization/locks/read'
+    'Microsoft.Authorization/locks/write'
+    'Microsoft.Authorization/locks/delete'
   ]
 }
 


### PR DESCRIPTION
# Problem

IOM policy 683 ("Azure Custom Role Administering Resource Locks not assigned") is triggered for all Azure registrations. The CrowdStrike custom role (`role-csreader`) lacks `Microsoft.Authorization/locks` permissions, causing the IOM to flag every registered subscription/management group.

Related: SUPPORT-29902

# Solution

Add `Microsoft.Authorization/locks/read`, `write`, and `delete` permissions to the existing `role-csreader` custom role definition at both subscription and management group scope.

No new roles or role assignments are needed — the existing assignment pipeline grants the updated role to the CrowdStrike service principal.

# Configuration

No new parameters or feature flags. Permissions are added unconditionally to the existing custom role.

# Security

Grants the CrowdStrike service principal the ability to manage resource locks on customer subscriptions/management groups. This is the minimum permission set required to resolve IOM policy 683.

# Test Plan

- Bicep build validation passes for both modified files and parent templates
- Deploy to a test subscription, verify the custom role includes lock permissions
- Confirm IOM policy 683 no longer triggers after role update

# Rollout

Standard progression. Existing deployments pick up new permissions on next re-deployment.
