### PR TITLE
chore(docs): update documentation to be SKU agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![CrowdStrike Falcon](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
 
-# Falcon Cloud Security Registration with Azure Bicep
+# Falcon Azure Registration with Bicep
 
-The Azure Bicep templates in this repository allow for an easy and seamless registration of Azure environments into CrowdStrike Falcon Cloud Security for asset inventory and real-time visibility and detection.
+The Azure Bicep templates in this repository allow for easy and seamless registration of Azure environments with Falcon for asset inventory and real-time visibility and detection.
 
 ## Contents
 1. [Overview](#overview)
@@ -18,8 +18,8 @@ The Azure Bicep templates in this repository allow for an easy and seamless regi
 
 ## Overview
 
-You can use the Bicep files in this repo to register either or both of these types of Azure entities to Falcon Cloud Security:
-- Azure management groups and all subscriptions in those management groups 
+You can use the Bicep files in this repo to register either or both of these types of Azure entities with the Falcon platform:
+- Azure management groups and all subscriptions in those management groups
 - Individual Azure subscriptions 
 
 The Bicep templates perform the following actions:
@@ -33,14 +33,14 @@ The Bicep templates perform the following actions:
   - Microsoft.Web/sites/config/list/Action
   - Microsoft.Web/sites/publish/action
 - If the `enableRealTimeVisibility` parameter is set to true, the templates also:
-   - Deploy an Azure Event Hubs namespace, two event hubs, and additional infrastructure to the subscription that has been designated as the default subscription, which is done via the `csInfraSubscriptionId` parameter. CrowdStrike uses this infrastructure to stream Entra ID sign-in and audit logs, as well as Azure activity logs, to Falcon Cloud Security.
+   - Deploy an Azure Event Hubs namespace, two event hubs, and additional infrastructure to the subscription that has been designated as the default subscription, which is done via the `csInfraSubscriptionId` parameter. CrowdStrike uses this infrastructure to stream Entra ID sign-in and audit logs, as well as Azure activity logs, to Falcon.
    - Create a Microsoft Entra ID diagnostic setting that forwards sign-in and audit logs to the newly-created event hub.
    - Individual subscription deployments only:
-      - Create an Azure activity log diagnostic setting in the subscription being registered with Falcon Cloud Security that forwards activity logs to the newly-created event hub.
+      - Create an Azure activity log diagnostic setting in the subscription being registered with CrowdStrike that forwards activity logs to the newly-created event hub.
    - If registering a management group:
       - Create an Azure activity log diagnostic setting in all active subscriptions that forwards activity logs to the newly-created event hub.
       - When `logIngestionSettings.activityLogSettings.deployRemediationPolicy` is set to `true`, create an Azure policy definition and management group assignment that will create Azure activity log diagnostic settings for new subscriptions to forward activity logs to the newly-created event hub.
-- If one of `enableDspm`/`enableVulnerabilityScanning` parameters are set to true:
+- If one of `enableDspm`/`enableVulnerabilityScanning` parameters are set to true (requires Falcon Cloud Security):
    - If `agentlessScanningLocationsPerSubscription` is specified, per subscription from the map, otherwise per subscription within specified registration scope:
       - Create a resource group with Key vault and Managed Identity in global resources location.
       - Create and assign a custom Scanning access role at subscription scope.
@@ -58,11 +58,11 @@ The Bicep templates perform the following actions:
 
 ## Prerequisites
 
-1. Create a registration for your Azure tenant on Falcon Cloud Security and grant admin consent to Falcon Cloud Security App
+1. Create a registration for your Azure tenant in the Falcon console and grant admin consent to the Falcon application
    - [US-1](https://falcon.crowdstrike.com/cloud-security/registration-v2/azure)
    - [US-2](https://falcon.us-2.crowdstrike.com/cloud-security/registration-v2/azure)
    - [EU-1](https://falcon.eu-1.crowdstrike.com/cloud-security/registration-v2/azure)
-2. Ensure you have a CrowdStrike API URL, client ID, and client secret for Falcon Cloud Security with `Cloud security Azure registration (Write)` scope. If you don't already have API credentials, you can set them up in the Falcon console. You must be a Falcon Administrator to access the API clients page:
+2. Ensure you have a CrowdStrike API URL, client ID, and client secret with `Cloud security Azure registration (Write)` scope. If you don't already have API credentials, you can set them up in the Falcon console. You must be a Falcon Administrator to access the API clients page:
    - [US-1](https://falcon.crowdstrike.com/api-clients-and-keys/)
    - [US-2](https://falcon.us-2.crowdstrike.com/api-clients-and-keys/)
    - [EU-1](https://falcon.eu-1.crowdstrike.com/api-clients-and-keys/clients)
@@ -87,7 +87,7 @@ The Bicep templates perform the following actions:
 
 ## Required permissions
 
-- **Owner** role for the Azure management groups and subscriptions to be integrated into Falcon Cloud Security
+- **Owner** role for the Azure management groups and subscriptions to be integrated with CrowdStrike
 
 ## Template parameters
 
@@ -100,8 +100,8 @@ You can use any of these methods to pass parameters:
 | Parameter name                                                                | Required | Description                                                                                                                                                                                                                                                                                                                                            |
 |-------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `csInfraSubscriptionId`                                                       | no       | Subscription ID where CrowdStrike infrastructure resources will be deployed. This subscription hosts shared resources like Event Hubs. Required when `enableRealTimeVisibility`, `enableDspm` or `enableVulnerabilityScanning` are set to `true`.                                                                                                      |
-| `managementGroupIds`                                                          | no       | List of management groups to be integrated into Falcon Cloud Security. Only used to register management groups.                                                                                                                                                                                                                                        |
-| `subscriptionIds`                                                             | no       | List of individual subscriptions to be integrated into Falcon Cloud Security.                                                                                                                                                                                                                                                                          |
+| `managementGroupIds`                                                          | no       | List of management groups to be registered with the Falcon platform. Only used to register management groups.                                                                                                                                                                                                                                        |
+| `subscriptionIds`                                                             | no       | List of individual subscriptions to be registered with the Falcon platform.                                                                                                                                                                                                                                                                          |
 | `location`                                                                    | no       | Azure location (region) where global resources will be deployed. Default is the deployment location.                                                                                                                                                                                                                                                   |
 | `resourceNamePrefix`                                                          | no       | Optional prefix added to all resource names for organization and identification purposes.                                                                                                                                                                                                                                                              |
 | `resourceNameSuffix`                                                          | no       | Optional suffix added to all resource names for organization and identification purposes.                                                                                                                                                                                                                                                              |
@@ -131,8 +131,8 @@ You can use any of these methods to pass parameters:
 | `logIngestionSettings.entraIdLogSettings.existingEventhub.namespaceName`      | no       | Name of the existing Azure Event Hubs namespace.                                                                                                                                                                                                                                                                                                       |
 | `logIngestionSettings.entraIdLogSettings.existingEventhub.name`               | no       | Name of the existing event hub instance to use.                                                                                                                                                                                                                                                                                                        |
 | `logIngestionSettings.entraIdLogSettings.existingEventhub.consumerGroupName`  | no       | Consumer group name in the existing event hub instance to use.                                                                                                                                                                                                                                                                                         |
-| `enableDspm`                                                                  | no       | Main toggle for Data Security Posture Management (DSPM).                                                                                                                                                                                                                                                                                               |
-| `enableVulnerabilityScanning`                                                 | no       | Main toggle for agentless vulnerability scanning.                                                                                                                                                                                                                                                                                                      |
+| `enableDspm`                                                                  | no       | Main toggle for Data Security Posture Management (DSPM). Requires Falcon Cloud Security.                                                                                                                                                                                                                                                                                               |
+| `enableVulnerabilityScanning`                                                 | no       | Main toggle for agentless vulnerability scanning. Requires Falcon Cloud Security.                                                                                                                                                                                                                                                                                                     |
 | `agentlessScanningLocations`                                                  | no       | List of locations (regions) to deploy agentless scanning environment (DSPM/Vulnerability scanning).                                                                                                                                                                                                                                                    |
 | `agentlessScanningLocationsPerSubscription`                                   | no       | A map of subscriptions to list of locations where agentless scanning environment will be deployed (DSPM/Vulnerability scanning).                                                                                                                                                                                                                       |
 | `agentlessScanningDeployNatGateway`                                           | no       | Indicates Agentless Scanning environment will be deployed with NAT Gateway. Default is `true`.                                                                                                                                                                                                                                                         |
@@ -208,7 +208,7 @@ param location = 'westeurope'
 
 1. Download this repo to your local computer.
 2. Open a new Terminal window and change directory to point at the downloaded repo.
-3. Run `az login` to log into Azure via the Azure CLI. Be sure to log into a subscription that is in the tenant you want to register with Falcon Cloud Security.
+3. Run `az login` to log into Azure via the Azure CLI. Be sure to log into a subscription that is in the tenant you want to register with CrowdStrike.
 4. Run the appropriate deployment command provided below.
 
 ### Deployment command for registering management groups and/or individual subscriptions
@@ -224,7 +224,7 @@ az stack mg create --name '<deployment stack name you want to use>' --location w
 ```
 
 > [!NOTE]
-> The `cs-deployment-management-group.bicep` template can be used to register a list of management groups (and all subscriptions in those management groups) and/or a list of individual subscriptions to CrowdStrike Falcon Cloud Security.
+> The `cs-deployment-management-group.bicep` template can be used to register a list of management groups (and all subscriptions in those management groups) and/or a list of individual subscriptions with CrowdStrike.
 
 To track progress of the deployment or if you encounter issues and want to see detailed error messages:
    - Open the Azure Portal.
@@ -269,7 +269,7 @@ To track progress of the deployment or if you encounter issues and want to see d
 
 ### Deployment command for registering the whole tenant
 
-To deploy Falcon Cloud Security integration for the entire tenant, you can use the management group deployment template with empty lists for both `managementGroupIds` and `subscriptionIds` parameters:
+To deploy CrowdStrike Falcon integration for the entire tenant, you can use the management group deployment template with empty lists for both `managementGroupIds` and `subscriptionIds` parameters:
 
 ```sh
 az stack mg create --name '<deployment stack name you want to use>' --location westus \
@@ -288,7 +288,7 @@ param managementGroupIds = []
 param subscriptionIds = []
 ```
 
-This configuration deploys the Falcon Cloud Security integration at the tenant root level, effectively covering all management groups and subscriptions in your Azure tenant.
+This configuration deploys the Falcon integration at the tenant root level, effectively covering all management groups and subscriptions in your Azure tenant.
 
 To track progress of the deployment:
    - Open the Azure Portal.
@@ -366,7 +366,7 @@ If you want to develop new content or improve on this collection, please open an
 
 ## Support
 
-This is a community-driven, open source project aimed to register Falcon Cloud Security with Azure using Bicep. While not an official CrowdStrike product, this repository is maintained by CrowdStrike and supported in collaboration with the open source developer community.
+This is a community-driven, open source project aimed to register Falcon with Azure using Bicep. While not an official CrowdStrike product, this repository is maintained by CrowdStrike and supported in collaboration with the open source developer community.
 
 For additional information, please refer to the [SUPPORT.md](SUPPORT.md) file.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 # Support
 
-This is a community-driven, open source project designed to register Falcon Cloud Security with Azure using Bicep. While not a formal CrowdStrike product, this project is maintained by CrowdStrike and supported in partnership with the open source developer community.
+This is a community-driven, open source project designed to register Azure entities with CrowdStrike Falcon using Bicep. While not a formal CrowdStrike product, this project is maintained by CrowdStrike and supported in partnership with the open source developer community.
 
 ## Issue Reporting and Questions
 

--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -2,12 +2,12 @@ import { LogIngestionSettings } from 'models/log-ingestion.bicep'
 
 targetScope = 'managementGroup'
 
-metadata name = 'CrowdStrike Falcon Cloud Security Integration'
-metadata description = 'Deploys CrowdStrike Falcon Cloud Security integration for asset inventory and real-time visibility and detection assessment'
+metadata name = 'Falcon platform integration with Azure'
+metadata description = 'Deploys the Falcon platform integration for asset inventory and real-time visibility and detection assessment'
 metadata owner = 'CrowdStrike'
 
 /*
-  This Bicep template deploys CrowdStrike Falcon Cloud Security integration for
+  This Bicep template deploys the Falcon platform integration for
   asset inventory and real-time visibility and detection assessment.
 
   Copyright (c) 2025 CrowdStrike, Inc.

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -2,11 +2,11 @@ import { LogIngestionSettings } from 'models/log-ingestion.bicep'
 
 targetScope = 'subscription'
 
-metadata name = 'CrowdStrike Falcon Cloud Security Integration'
-metadata description = 'Deploys CrowdStrike Falcon Cloud Security integration for asset inventory and real-time visibility and detection assessment'
+metadata name = 'Falcon platform integration with Azure'
+metadata description = 'Deploys the Falcon platform integration for asset inventory and real-time visibility and detection assessment'
 metadata owner = 'CrowdStrike'
 /*
-  This Bicep template deploys CrowdStrike Falcon Cloud Security integration for
+  This Bicep template deploys the Falcon platform integration for
   asset inventory and real-time visibility and detection assessment.
 
   Copyright (c) 2025 CrowdStrike, Inc.

--- a/modules/update-registration/updateRegistration.bicep
+++ b/modules/update-registration/updateRegistration.bicep
@@ -1,5 +1,5 @@
 /*
-  This Bicep template update the Event Hub settings back to Falcon Cloud Security.
+  This Bicep template updates the Event Hub settings back to the Falcon platform.
   Copyright (c) 2025 CrowdStrike, Inc.
 */
 


### PR DESCRIPTION
### Summary
- Updates repository documentation and templates to be SKU-agnostic
- Notes Falcon Cloud Security SKU requirement for some features

 #### Changes
  - **README.md**: Updated documentation to support both DSPM and Vulnerability Scanning features with generic CrowdStrike terminology
  - **SUPPORT.md**: Replaced product-specific references with generic language
  - **Bicep Templates**: Updated parameter descriptions and documentation comments to be SKU-agnostic
    - `cs-deployment-management-group.bicep`
    - `cs-deployment-subscription.bicep`
    - `modules/update-registration/updateRegistration.bicep`

  #### Motivation
  This change makes the docs more flexible and future-proof by removing dependencies on specific product names