### PR TITLE
fix(azure-bicep-cloud-registration): CSPG-98255 Exclude Gov-unsupported Entra ID diagnostic log categories

### DIFF
--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -332,6 +332,7 @@ module logIngestion 'modules/cs-log-ingestion-mg.bicep' = if (shouldDeployLogIng
     location: location
     env: env
     tags: tags
+    accountType: accountType
   }
   dependsOn: [
     infraResourceGroup

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -324,6 +324,7 @@ module logIngestion 'modules/cs-log-ingestion-sub.bicep' = if (shouldDeployLogIn
     location: location
     env: env
     tags: tags
+    accountType: accountType
   }
   dependsOn: [
     infraResourceGroup

--- a/modules/cs-log-ingestion-mg.bicep
+++ b/modules/cs-log-ingestion-mg.bicep
@@ -51,6 +51,9 @@ param env string
 @description('Tags to be applied to all deployed resources. Used for resource organization, governance, and cost tracking.')
 param tags object
 
+@description('Azure cloud type for this registration. Use "commercial" for standard Azure or "gov" for Azure Government. Empty string is treated as commercial.')
+param accountType string = ''
+
 var environment = length(env) > 0 ? '-${env}' : env
 
 // Deployment for subscriptions
@@ -69,6 +72,7 @@ module deploymentForSubs 'log-ingestion/logIngestionForSub.bicep' = {
     location: location
     env: env
     tags: tags
+    accountType: accountType
   }
 }
 

--- a/modules/cs-log-ingestion-sub.bicep
+++ b/modules/cs-log-ingestion-sub.bicep
@@ -43,6 +43,9 @@ param falconIpAddresses array
 @description('List of Azure subscription IDs to monitor. These subscriptions will be configured for CrowdStrike monitoring.')
 param subscriptionIds array
 
+@description('Azure cloud type for this registration. Use "commercial" for standard Azure or "gov" for Azure Government. Empty string is treated as commercial.')
+param accountType string = ''
+
 var environment = length(env) > 0 ? '-${env}' : env
 
 module deploymentForSubs 'log-ingestion/logIngestionForSub.bicep' = {
@@ -59,6 +62,7 @@ module deploymentForSubs 'log-ingestion/logIngestionForSub.bicep' = {
     location: location
     env: env
     tags: tags
+    accountType: accountType
   }
 }
 

--- a/modules/log-ingestion/entraLog.bicep
+++ b/modules/log-ingestion/entraLog.bicep
@@ -15,7 +15,42 @@ param eventHubName string
 @description('Name for the diagnostic settings configuration that sends Entra ID logs to the Event Hub. Used for identification in the Azure portal.')
 param diagnosticSettingsName string
 
-/* 
+@description('Azure cloud type for this registration. Use "commercial" for standard Azure or "gov" for Azure Government. Empty string is treated as commercial.')
+param accountType string = ''
+
+/*
+  Full set of Microsoft Entra ID diagnostic log categories collected for
+  CrowdStrike. Order is preserved for stability of the generated logs array.
+*/
+var allEntraLogCategories = [
+  'AuditLogs'
+  'SignInLogs'
+  'NonInteractiveUserSignInLogs'
+  'ServicePrincipalSignInLogs'
+  'ManagedIdentitySignInLogs'
+  'ADFSSignInLogs'
+  'MicrosoftGraphActivityLogs'
+  'ProvisioningLogs'
+  'UserRiskEvents'
+  'RiskyUsers'
+  'RiskyServicePrincipals'
+  'ServicePrincipalRiskEvents'
+  'NetworkAccessTrafficLogs'
+]
+
+// Categories not supported by Azure Government. NetworkAccessTrafficLogs is a
+// Microsoft Entra Global Secure Access category unavailable in Gov, and ARM
+// rejects the whole diagnostic settings resource if any listed category is
+// unsupported. Add further Gov-unsupported categories here as they are found.
+var govUnsupportedCategories = [
+  'NetworkAccessTrafficLogs'
+]
+
+var selectedCategories = accountType == 'gov'
+  ? filter(allEntraLogCategories, category => !contains(govUnsupportedCategories, category))
+  : allEntraLogCategories
+
+/*
   Deploy Diagnostic Settings for Microsoft Entra ID Logs
 
   Collect Microsoft Entra ID logs and submit them to CrowdStrike
@@ -30,111 +65,13 @@ resource entraDiagnosticSettings 'microsoft.aadiam/diagnosticSettings@2017-04-01
   properties: {
     eventHubAuthorizationRuleId: eventHubAuthorizationRuleId
     eventHubName: eventHubName
-    logs: [
-      {
-        category: 'AuditLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
+    logs: map(selectedCategories, category => {
+      category: category
+      enabled: true
+      retentionPolicy: {
+        days: 0
+        enabled: false
       }
-      {
-        category: 'SignInLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'NonInteractiveUserSignInLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'ServicePrincipalSignInLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'ManagedIdentitySignInLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'ADFSSignInLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'MicrosoftGraphActivityLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'ProvisioningLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'UserRiskEvents'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'RiskyUsers'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'RiskyServicePrincipals'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'ServicePrincipalRiskEvents'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-      {
-        category: 'NetworkAccessTrafficLogs'
-        enabled: true
-        retentionPolicy: {
-          days: 0
-          enabled: false
-        }
-      }
-    ]
+    })
   }
 }

--- a/modules/log-ingestion/logIngestionForSub.bicep
+++ b/modules/log-ingestion/logIngestionForSub.bicep
@@ -36,6 +36,9 @@ param activityLogSettings ActivityLogSettings
 @description('Configuration settings for Microsoft Entra ID log collection and monitoring.')
 param entraIdLogSettings EntraIdLogSettings
 
+@description('Azure cloud type for this registration. Use "commercial" for standard Azure or "gov" for Azure Government. Empty string is treated as commercial.')
+param accountType string = ''
+
 @description('List of IP addresses of CrowdStrike Falcon service. Please refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0 for the IP address list of your Falcon region.')
 param falconIpAddresses array
 
@@ -97,6 +100,7 @@ module entraDiagnosticSettings 'entraLog.bicep' = if (shouldDeployEventhubForEnt
     diagnosticSettingsName: '${resourceNamePrefix}diag-cslogentid${environment}${resourceNameSuffix}'
     eventHubName: eventHub.outputs.eventhubs.entraLog.eventHubName
     eventHubAuthorizationRuleId: eventHub.outputs.eventhubs.entraLog.eventHubAuthorizationRuleId
+    accountType: accountType
   }
 }
 


### PR DESCRIPTION
## Summary
- Gov (Azure Government) customers cannot deploy the IDAAS connector: ARM rejects the entire `microsoft.aadiam/diagnosticSettings` resource with `Category 'NetworkAccessTrafficLogs' is not supported`, because that category (Microsoft Entra Global Secure Access) is unavailable in Azure Government clouds.
- `modules/log-ingestion/entraLog.bicep` hardcoded all 13 categories unconditionally with no cloud branching, even though the template is shared between Commercial and Gov.
- Plumbs the existing `accountType` param (`"commercial"` / `"gov"` / `""`, already declared at both entry points) through the log-ingestion module chain into `entraLog.bicep`, and excludes `NetworkAccessTrafficLogs` when `accountType == 'gov'`.
- `accountType=''`/`'commercial'` keeps all 13 categories (no regression). `accountType='gov'` drops to 12.
- The other 6 categories added in CSPG-91459 (`MicrosoftGraphActivityLogs`, `ProvisioningLogs`, `UserRiskEvents`, `RiskyUsers`, `RiskyServicePrincipals`, `ServicePrincipalRiskEvents`) were validated against Microsoft's Azure Government documentation — all are supported, so only `NetworkAccessTrafficLogs` is excluded.

JIRA: [CSPG-98255](https://jira.cs.sys/browse/CSPG-98255)

## Test plan
- [x] `az bicep build` on both entry templates (`cs-deployment-management-group.bicep`, `cs-deployment-subscription.bicep`) — exits 0, no errors/warnings
- [x] Compiled ARM template for `entraLog.bicep` confirms `selectedCategories` uses `if(equals(accountType, 'gov'), filter(...), allEntraLogCategories)`
- [x] `accountType=''` branch retains all 13 categories including `NetworkAccessTrafficLogs` (regression guard)
- [x] `accountType='gov'` branch drops to 12 categories, `NetworkAccessTrafficLogs` absent
- [ ] Gov end-to-end: re-run `az stack mg create` with `accountType='gov'` against a Gov tenant to confirm the original customer error no longer occurs