### PR TITLE
chore: Add eventHubSettings output with management_type

### DIFF
--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -430,6 +430,31 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
   }
 }
 
+var eventHubSettings = shouldDeployLogIngestion
+  ? concat(
+      logIngestion!.outputs.activityLogEventHubId != ''
+        ? [
+            {
+              purpose: 'activity_logs'
+              event_hub_id: logIngestion!.outputs.activityLogEventHubId
+              consumer_group: logIngestion!.outputs.activityLogEventHubConsumerGroupName
+              management_type: logIngestion!.outputs.activityLogEventHubManagementType
+            }
+          ]
+        : [],
+      logIngestion!.outputs.entraLogEventHubId != ''
+        ? [
+            {
+              purpose: 'entra_logs'
+              event_hub_id: logIngestion!.outputs.entraLogEventHubId
+              consumer_group: logIngestion!.outputs.entraLogEventHubConsumerGroupName
+              management_type: logIngestion!.outputs.entraLogEventHubManagementType
+            }
+          ]
+        : []
+    )
+  : []
+
 output customReaderRoleNameForSubs array = assetInventory.outputs.customRoleNameForSubs
 output customReaderRoleNameForMGs array = assetInventory.outputs.customRoleNameForMGs
 output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.activityLogEventHubId : ''
@@ -440,3 +465,4 @@ output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outp
 output entraLogEventHubConsumerGroupName string = shouldDeployLogIngestion
   ? logIngestion!.outputs.entraLogEventHubConsumerGroupName
   : ''
+output eventHubSettings array = eventHubSettings

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -379,6 +379,31 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
   }
 }
 
+var eventHubSettings = shouldDeployLogIngestion
+  ? concat(
+      logIngestion!.outputs.activityLogEventHubId != ''
+        ? [
+            {
+              purpose: 'activity_logs'
+              event_hub_id: logIngestion!.outputs.activityLogEventHubId
+              consumer_group: logIngestion!.outputs.activityLogEventHubConsumerGroupName
+              management_type: logIngestion!.outputs.activityLogEventHubManagementType
+            }
+          ]
+        : [],
+      logIngestion!.outputs.entraLogEventHubId != ''
+        ? [
+            {
+              purpose: 'entra_logs'
+              event_hub_id: logIngestion!.outputs.entraLogEventHubId
+              consumer_group: logIngestion!.outputs.entraLogEventHubConsumerGroupName
+              management_type: logIngestion!.outputs.entraLogEventHubManagementType
+            }
+          ]
+        : []
+    )
+  : []
+
 output customRoleNameForSubs array = assetInventory.outputs.customRoleNameForSubs
 output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.activityLogEventHubId : ''
 output activityLogEventHubConsumerGroupName string = shouldDeployLogIngestion
@@ -388,3 +413,4 @@ output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outp
 output entraLogEventHubConsumerGroupName string = shouldDeployLogIngestion
   ? logIngestion!.outputs.entraLogEventHubConsumerGroupName
   : ''
+output eventHubSettings array = eventHubSettings

--- a/modules/cs-log-ingestion-mg.bicep
+++ b/modules/cs-log-ingestion-mg.bicep
@@ -100,3 +100,5 @@ output activityLogEventHubId string = deploymentForSubs.outputs.activityLogEvent
 output activityLogEventHubConsumerGroupName string = deploymentForSubs.outputs.activityLogEventHubConsumerGroupName
 output entraLogEventHubId string = deploymentForSubs.outputs.entraLogEventHubId
 output entraLogEventHubConsumerGroupName string = deploymentForSubs.outputs.entraLogEventHubConsumerGroupName
+output activityLogEventHubManagementType string = deploymentForSubs.outputs.activityLogEventHubManagementType
+output entraLogEventHubManagementType string = deploymentForSubs.outputs.entraLogEventHubManagementType

--- a/modules/cs-log-ingestion-sub.bicep
+++ b/modules/cs-log-ingestion-sub.bicep
@@ -70,3 +70,5 @@ output activityLogEventHubId string = deploymentForSubs.outputs.activityLogEvent
 output activityLogEventHubConsumerGroupName string = deploymentForSubs.outputs.activityLogEventHubConsumerGroupName
 output entraLogEventHubId string = deploymentForSubs.outputs.entraLogEventHubId
 output entraLogEventHubConsumerGroupName string = deploymentForSubs.outputs.entraLogEventHubConsumerGroupName
+output activityLogEventHubManagementType string = deploymentForSubs.outputs.activityLogEventHubManagementType
+output entraLogEventHubManagementType string = deploymentForSubs.outputs.entraLogEventHubManagementType

--- a/modules/log-ingestion/eventHub.bicep
+++ b/modules/log-ingestion/eventHub.bicep
@@ -214,6 +214,7 @@ output eventhubs object = {
     eventHubConsumerGrouopName: shouldDeployActivityLog
       ? '$Default'
       : activityLogSettings.?existingEventhub.?consumerGroupName ?? ''
+    managementType: shouldUseExistingEventHubForActivityLog ? 'unmanaged' : (shouldDeployActivityLog ? 'managed' : '')
   }
   entraLog: {
     eventHubNamespaceName: shouldUseExistingEventHubForEntraLog
@@ -236,5 +237,6 @@ output eventhubs object = {
     eventHubConsumerGrouopName: shouldDeployEntraLog
       ? '$Default'
       : entraLogSettings.?existingEventhub.?consumerGroupName ?? ''
+    managementType: shouldUseExistingEventHubForEntraLog ? 'unmanaged' : (shouldDeployEntraLog ? 'managed' : '')
   }
 }

--- a/modules/log-ingestion/logIngestionForSub.bicep
+++ b/modules/log-ingestion/logIngestionForSub.bicep
@@ -114,3 +114,5 @@ output activityLogEventHubConsumerGroupName string = eventHub.outputs.eventhubs.
 output entraLogEventHubName string = eventHub.outputs.eventhubs.entraLog.eventHubName
 output entraLogEventHubId string = eventHub.outputs.eventhubs.entraLog.eventHubId
 output entraLogEventHubConsumerGroupName string = eventHub.outputs.eventhubs.entraLog.eventHubConsumerGrouopName
+output activityLogEventHubManagementType string = eventHub.outputs.eventhubs.activityLog.managementType
+output entraLogEventHubManagementType string = eventHub.outputs.eventhubs.entraLog.managementType


### PR DESCRIPTION
## Summary

Adds a new `eventHubSettings` array output to both root templates, in the same
`{purpose, event_hub_id, consumer_group}` shape already used for the PATCH body, plus a new `management_type`
field set to `"unmanaged"` when an existing Event Hub is being reused (`*.existingEventhub.use == true`) or
`"managed"` when the template deployed the Event Hub itself.

`management_type` is computed once, in `modules/log-ingestion/eventHub.bicep`, from the `shouldUseExistingEventHubFor*`
/ `shouldDeploy*` variables that already gate the real Event Hub deployment logic - avoiding a second, potentially
drifting derivation at the root templates. It's then plumbed up through the existing output chain
(`eventHub.bicep` -> `logIngestionForSub.bicep` -> `cs-log-ingestion-sub.bicep` / `cs-log-ingestion-mg.bicep` ->
root templates) alongside the fields that already take that path.

This is purely additive: the four existing flat outputs are unchanged and still consumed internally by
`cs-update-registration-rg.bicep`. The live PATCH call (`cs-update-registration-rg.bicep` /
`updateRegistration.bicep` / `Update-Registration.ps1`) is intentionally untouched, since `management_type` isn't
part of the `AzureEventHubSettings` API model yet - that's out of scope for this change.

## Configuration

N/A - no new input parameters, no schema changes to `models/log-ingestion.bicep`. `management_type` is derived
entirely from existing settings.

## Security

N/A - output-only change, no new data paths, no secrets or credentials involved.

## Test Plan

- `az bicep build` on both root templates succeeds, confirming the whole module chain compiles.
- `az bicep lint` clean on all 6 changed files.
- `az bicep format` produces no diff on any of the 6 changed files.
- Inspected compiled ARM JSON (`az bicep build --stdout`) to confirm `eventHubSettings` resolves to an array of
  `{purpose, event_hub_id, consumer_group, management_type}`, correctly tracing through the module chain to
  `logIngestion.outputs.*EventHubManagementType`.
- Verified both directions of `management_type` by inspecting the compiled `managementType` expression in
  `eventHub.bicep`: it branches on `shouldUseExistingEventHubFor*` (-> `"unmanaged"`) vs `shouldDeploy*` (->
  `"managed"`), the same variables gating real Event Hub deployment.
- Deployed to a live management-group stack (`whmav-` prefix) and confirmed via
  `az stack mg show --query "outputs.eventHubSettings"` that the output resolves correctly in practice:
  `management_type: "managed"` for both `activity_logs` and `entra_logs` in the default (no existing Event Hub)
  configuration.
```json
{
  ...,
  "eventHubSettings": {
    "type": "Array",
    "value": [
      {
        "consumer_group": "$Default",
        "event_hub_id": "/subscriptions/.../resourceGroups/whmav-rg-cs-prod-mg/providers/Microsoft.EventHub/namespaces/whmav-evhns-cslog-.../eventhubs/whmav-evh-cslogact-prod-westus-mg",
        "management_type": "managed",
        "purpose": "activity_logs"
      },
      {
        "consumer_group": "$Default",
        "event_hub_id": "/subscriptions/.../resourceGroups/whmav-rg-cs-prod-mg/providers/Microsoft.EventHub/namespaces/whmav-evhns-cslog-.../eventhubs/whmav-evh-cslogentid-prod-westus-mg",
        "management_type": "managed",
        "purpose": "entra_logs"
      }
    ]
  }
}
```

## Rollout Plan

Purely additive output - no behavior change to any deployed resource. Safe to merge and release through the
standard progression with no special sequencing or rollback considerations.
